### PR TITLE
spec v0.1 hardening: schema closure, XSS sanitizer, extension mechanism, CLI validator

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Catch-all reviewer for the repo. Per-area owners can be added below as
+# the project grows and more contributors step up.
+* @ym259

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
       - run: npm test
       - name: npm pack dry-run (catches broken files globs)
         run: |
-          for pkg in packages/renderer packages/jp-court packages/mcp; do
+          for pkg in packages/renderer packages/jp-court packages/mcp packages/cli; do
             (cd "$pkg" && npm pack --dry-run)
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: npm run typecheck
+      - run: npm test
+      - name: npm pack dry-run (catches broken files globs)
+        run: |
+          for pkg in packages/renderer packages/jp-court packages/mcp; do
+            (cd "$pkg" && npm pack --dry-run)
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to the `.agent` format spec and reference implementations.
+The format follows semver; see `SPEC.md` § 5 for what counts as breaking.
+
+## [Unreleased] — spec v0.1 hardening
+
+### Spec / schema
+
+- Root documents now MAY carry a `$schema` string for editor integration.
+- Removed legacy `inheritance-diagram` section type from the schema; writers
+  MUST emit `family-graph`. Renderers SHOULD continue to accept the old
+  `type` at runtime as a backward-compatible alias (§ 4.13 note).
+- Closed nested object schemas with `additionalProperties: false` across all
+  section types and root containers. Section wrappers use
+  `unevaluatedProperties: false` so the combined `SectionBase + data`
+  contract rejects arbitrary extras.
+
+### Renderer
+
+- Added `sanitizeSvgForEmbed` — DOMParser-based allowlist walk with a
+  hardened regex fallback for Node. Used by `buildPrintableHtml` before
+  embedding user-supplied SVG.
+- Added `SPEC_MAJOR` export + unsupported-major warning banner
+  (spec § 3.1).
+- `notes` and `report` section content is plain text; newlines preserved.
+  (README corrected.)
+
+### MCP
+
+- `render_agent_inline` now validates the full document against the JSON
+  Schema via Ajv and returns a structured error on failure instead of
+  shallow "is `sections` an array?" check.
+- MCP UI App version is injected from `package.json` at build time
+  (`__APP_VERSION__`), replacing the previously hardcoded string.
+- `tsconfig.ui.json` added so `ui-client.tsx` is now typechecked in CI.
+- README wording corrected to reflect the inlined-renderer architecture
+  (no iframe, default CSP sufficient).
+
+### CI / OSS
+
+- New `.github/workflows/ci.yml` — build + typecheck + test + `npm pack
+  --dry-run` on every push/PR.
+- Added `SECURITY.md`, `CHANGELOG.md`, `CODEOWNERS`.

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ That combination is what this spec defines.
 }
 ```
 
-An agent reads this JSON. It sees *"this project has a kanban of workstreams, I remember these observations about the user."* It writes back changes to the same file. A human opens the same file in any conformant renderer and sees a rendered kanban + an editable instructions panel + an observable memory list.
+An agent reads this JSON. It sees *"this project has a kanban of workstreams, I remember these observations about the user."* It writes back changes to the same file. A human opens the same file in any conformant renderer and sees the rendered sections as an interactive dashboard.
 
 ---
 
-## 12 section types
+## Supported section types
 
-Each section has a closed schema. The agent chooses which section type fits a concept.
+The core renderer defines 13 built-in section types, plus the deprecated `inheritance-diagram` alias and `x-<vendor>:<name>` extension sections. The agent chooses which section type fits a concept.
 
 | Type | Use for |
 |---|---|
@@ -105,6 +105,9 @@ Each section has a closed schema. The agent chooses which section type fits a co
 | `form` | Input fields and submissions |
 | `links` | External URLs grouped by category |
 | `references` | Local file references (path + memo) |
+| `family-graph` | Genealogy / inheritance / kinship diagrams |
+| `inheritance-diagram` | Deprecated alias for `family-graph` |
+| `x-<vendor>:<name>` | Vendor-defined extension sections rendered by plugins or fallback UI |
 
 See [SPEC.md](./SPEC.md) for the full field list of each.
 
@@ -146,7 +149,7 @@ Want to add a second renderer (Obsidian plugin, VS Code extension, MCP Apps serv
 
 ## Status and roadmap
 
-- ✅ **v0.1 draft** (this repo) — 12 section types, JSON Schema, examples
+- ✅ **v0.1 draft** (this repo) — 13 built-in section types, deprecated alias support, extension-section typing, JSON Schema, examples
 - ⏳ **v0.2** — formalize extension mechanism (custom section types), stabilize ID conventions
 - ⏳ **v0.3** — relations between sections (e.g. a `log` entry links to a `kanban` item)
 - ⏳ **v1.0** — stable; breaking changes require major version bump

--- a/README.md
+++ b/README.md
@@ -140,8 +140,6 @@ This repository includes the reference implementation as a monorepo:
 - **[`packages/mcp`](./packages/mcp)** — the MCP Apps server published as [`@agent-format/mcp`](https://www.npmjs.com/package/@agent-format/mcp).
 - **[`packages/claude-plugin`](./packages/claude-plugin)** — a Claude Code skill that teaches Claude to write `.agent` files instead of HTML artifacts when asked to visualize or structure content.
 
-A full desktop integration exists in **[Tsuzuri](https://github.com/knorq-ai/tsuzuri)** (Tauri + web), which reads/writes `.agent` files with Claude Code integration.
-
 Want to add a second renderer (Obsidian plugin, VS Code extension, MCP Apps server)? See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Threat model
+
+`.agent` files are typically produced by an LLM and consumed by a client
+(renderer, viewer, or MCP Apps UI) running in the user's browser or editor.
+Anywhere a string from the file reaches the DOM or filesystem, the content
+must be treated as **untrusted input**.
+
+Primary surfaces:
+
+| Surface | Risk | Mitigation |
+|---|---|---|
+| `url` fields (links, references) | `javascript:` / `data:` XSS | Protocol allowlist in `LinksSection`; sanitizer rejects the same schemes in SVG/print output |
+| `color` fields (kanban labels, metrics) | CSS injection | Regex allowlist (hex / `rgb()` / `hsl()` numeric only) |
+| `svgMarkup` param to `buildPrintableHtml` | SVG XSS via `<script>`, `on*`, `url(javascript:)`, `<use href>` | `sanitizeSvgForEmbed` — DOMParser allowlist walk in browser, hardened regex in bare Node |
+| `.agent` file path (MCP `render_agent_file`) | Path traversal, symlink exfil, arbitrary file read | Extension gate + symlink refusal + size cap in `resolve.ts` |
+| Inline `.agent` JSON (MCP `render_agent_inline`) | Garbage-renderer / payload injection | Full JSON-Schema validation via Ajv at tool entry |
+| Viewer `#<encoded-json>` URL form | Cache poisoning, brand-impersonation | Document that the hash is never sent to server; parse client-side only |
+
+## Reporting a vulnerability
+
+Email **security@knorq.ai** with a reproducer. We aim to acknowledge within
+72 hours and issue a patch release within 14 days for confirmed issues.
+
+Do **not** open public GitHub issues for security reports.
+
+## Known limitations
+
+- The SVG sanitizer is defense-in-depth, not a substitute for a page-level
+  Content-Security-Policy. Production embedders should also set a strict CSP.
+- `references[].filePath` is displayed as text; renderers do not follow it
+  by default. If you build an editor that does, require explicit user consent
+  per path.
+- `.agent` documents declaring a major version greater than the renderer's
+  `SPEC_MAJOR` are rendered with a warning banner, not rejected outright.
+  Callers that require strict major-rejection should pre-filter.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,6 @@
 # Agent File Format — Specification v0.1 (Draft)
 
 **Status:** Draft. Last updated 2026-04-17.
-**Editors:** This is a working draft extracted from the [Tsuzuri](https://github.com/knorq-ai/tsuzuri) reference implementation.
 
 ---
 
@@ -120,7 +119,15 @@ Every section conforms to `SectionBase` plus a type-specific `data` payload:
 }
 ```
 
-`SectionType` is one of: `kanban`, `checklist`, `notes`, `timeline`, `table`, `log`, `metrics`, `diagram`, `report`, `form`, `links`, `references`, `family-graph`.
+`SectionType` is one of the core types — `kanban`, `checklist`, `notes`, `timeline`, `table`, `log`, `metrics`, `diagram`, `report`, `form`, `links`, `references` — or a namespaced **extension type** of the form `x-<vendor>:<name>` (e.g. `x-agent-format:family-graph`; see § 7). Core renderers that don't understand an extension type MUST fall back to the "Unknown section" placeholder rather than erroring (§ 6.2).
+
+**Standard extensions bundled with the reference implementation:**
+
+| Type | Purpose | Pack |
+|---|---|---|
+| `family-graph` | Family tree / genealogy graph with optional jurisdiction-specific visual variants | `@agent-format/renderer` (default) + `@agent-format/jp-court` (jp-court variant plugin) |
+
+`family-graph` is accepted unprefixed for backward compatibility with v0.1 documents shipped before § 7 was formalized. Writers targeting v0.2+ SHOULD use the `x-agent-format:family-graph` form for forward-compatible extension registration.
 
 **Rendering fidelity (normative):** A conforming renderer MUST render every item in `data` as authored. It MUST NOT filter, hide, omit, deduplicate, or algorithmically derive which items belong in the output. Section-specific style variants (e.g. `family-graph.variant = "jp-court"`) change visual presentation only; they do not change the set of rendered entities. If a producer wants a narrower output, it MUST author the file with only the intended entities — not rely on render-time filtering.
 
@@ -380,9 +387,26 @@ A conforming reader SHOULD:
 
 ## 7. Extensions
 
-Writers MAY include top-level fields not defined in this spec, prefixed with `x-` (e.g. `x-tsuzuri-snapshot-id`). Readers MUST preserve `x-*` fields on round-trip.
+### 7.1 Top-level extension fields
 
-Custom section types are not yet standardized. v0.2 will formalize an extension mechanism. Until then, implementations MAY add section types but SHOULD document them and accept that interop is not guaranteed.
+Writers MAY include top-level fields not defined in this spec, prefixed with `x-` (e.g. `x-acme-snapshot-id`). Readers MUST preserve `x-*` fields on round-trip.
+
+### 7.2 Extension section types
+
+Custom section types MUST use a namespaced identifier of the form `x-<vendor>:<name>` where `<vendor>` is a stable, DNS-like vendor tag the author controls and `<name>` is a kebab-case section name. Examples: `x-agent-format:family-graph`, `x-acme:burndown-chart`.
+
+Requirements:
+
+1. Vendors MUST NOT reuse another vendor's tag. The prefix exists so two independent authors can ship extensions with the same `<name>` without collision.
+2. The `data` payload of an extension section has no schema constraint from the core spec. Writers SHOULD publish a schema at `<vendor>/agent-format/<name>.schema.json` and reference it from documentation.
+3. Readers that don't recognize an extension type MUST render the "Unknown section" placeholder per § 6.2. Readers MUST NOT error, MUST NOT drop, and MUST preserve the section on round-trip.
+4. Conflicts between renderer plugins for the same `(type, variant)` pair are broken by registration order — earlier plugins win.
+
+The core spec reserves the bare (unprefixed) section types listed in § 4 plus `family-graph` (grandfathered for v0.1 compatibility). All future core type additions will ship with a major-version bump so prefixed extensions remain forward-compatible.
+
+### 7.3 Renderer plugin API
+
+The reference TypeScript renderer exposes a `RendererPlugin` interface so extension packs can register a React component for a `(type, variant?)` pair without touching the core renderer. See `packages/renderer/src/plugins.ts` and the `@agent-format/jp-court` pack for a worked example.
 
 ---
 
@@ -394,12 +418,20 @@ Custom section types are not yet standardized. v0.2 will formalize an extension 
 
 ---
 
-## 9. Open questions (v0.2 candidates)
+## 9. Roadmap
 
-- **Extension mechanism** for custom section types (namespaced `type: "x-mytype"`?).
-- **Relations** between sections: e.g. a `log` entry referencing a `kanban` item by ID.
-- **Binary attachments**: should the format inline images or require external refs?
-- **Multi-agent files**: multiple `config` blocks in one file?
-- **Schema URL in document**: `$schema` field for tooling integration.
+### 9.1 Scheduled for v0.2
+
+- **Drop the unprefixed `family-graph` type from `SectionBase.type`.** Writers MUST already emit `family-graph` today (§ 4.12), but the core enum still accepts it alongside the namespaced form for v0.1 compat. v0.2 renderers SHOULD accept the bare form at runtime as a backward alias; schema validation will require `x-agent-format:family-graph`.
+- **Relations between sections**: e.g. a `log` entry referencing a `kanban` item by stable ID. Current workaround is ad-hoc ID coupling.
+- **Binary attachments**: choose between inlined base64 blobs and external refs with integrity hashes. Today the format has no normative answer.
+- **Multi-agent files**: multiple `config` blocks per document (currently 1:1).
+
+### 9.2 Resolved in v0.1 (historical)
+
+The following were v0.2 candidates in earlier drafts and are now settled:
+
+- ~~Extension mechanism for custom section types~~ → formalized in § 7.2 (`x-<vendor>:<name>`).
+- ~~`$schema` field for editor integration~~ → accepted at document root; see § 3.
 
 Feedback welcome via GitHub issues.

--- a/examples/inheritance-jp-3gen.agent
+++ b/examples/inheritance-jp-3gen.agent
@@ -10,7 +10,7 @@
   "sections": [
     {
       "id": "sec-1",
-      "type": "inheritance-diagram",
+      "type": "family-graph",
       "label": "相続関係説明図（北田 宗太郎 被相続人）",
       "icon": "⚖️",
       "order": 0,

--- a/examples/minimal.agent
+++ b/examples/minimal.agent
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://agent-format.org/schemas/v0.1/agent.schema.json",
   "version": "0.1",
   "name": "Minimal example",
   "description": "The smallest valid agent file.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,10 @@
         "vitest": "^2.0.0"
       }
     },
+    "node_modules/@agent-format/cli": {
+      "resolved": "packages/cli",
+      "link": true
+    },
     "node_modules/@agent-format/jp-court": {
       "resolved": "packages/jp-court",
       "link": true
@@ -4402,6 +4406,22 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "packages/cli": {
+      "name": "@agent-format/cli",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.0",
+        "ajv-formats": "^3.0.0"
+      },
+      "bin": {
+        "agent-format": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.4.0"
+      }
+    },
     "packages/jp-court": {
       "name": "@agent-format/jp-court",
       "version": "0.1.2",
@@ -4426,10 +4446,12 @@
       "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
-        "@agent-format/jp-court": "^0.1.2",
-        "@agent-format/renderer": "^0.1.5",
+        "@agent-format/jp-court": "0.1.2",
+        "@agent-format/renderer": "0.1.5",
         "@modelcontextprotocol/ext-apps": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "ajv": "^8.17.0",
+        "ajv-formats": "^3.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "zod": "^3.23.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "packages/*"
   ],
   "scripts": {
+    "pretest": "npm run build -w @agent-format/cli",
     "build": "npm run build -w @agent-format/renderer && npm run build -w @agent-format/jp-court && npm run build -w @agent-format/viewer && npm run build -w @agent-format/mcp && npm run build -w @agent-format/cli",
     "dev": "npm run dev -w @agent-format/viewer",
     "dev:renderer": "npm run dev -w @agent-format/renderer",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build -w @agent-format/renderer && npm run build -w @agent-format/jp-court && npm run build -w @agent-format/viewer && npm run build -w @agent-format/mcp",
+    "build": "npm run build -w @agent-format/renderer && npm run build -w @agent-format/jp-court && npm run build -w @agent-format/viewer && npm run build -w @agent-format/mcp && npm run build -w @agent-format/cli",
     "dev": "npm run dev -w @agent-format/viewer",
     "dev:renderer": "npm run dev -w @agent-format/renderer",
-    "typecheck": "npm run typecheck -w @agent-format/renderer && npm run typecheck -w @agent-format/jp-court && npm run typecheck -w @agent-format/viewer && npm run typecheck -w @agent-format/mcp",
+    "typecheck": "npm run typecheck -w @agent-format/renderer && npm run typecheck -w @agent-format/jp-court && npm run typecheck -w @agent-format/viewer && npm run typecheck -w @agent-format/mcp && npm run typecheck -w @agent-format/cli",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/claude-plugin/skills/agent-format/SKILL.md
+++ b/packages/claude-plugin/skills/agent-format/SKILL.md
@@ -9,7 +9,7 @@ When the user asks you to structure or visualize content, prefer writing an `.ag
 
 ## Why this skill exists
 
-HTML artifacts for dashboards are verbose (hundreds of lines of markup), static, and round-trip-lossy — if the user drags a kanban card, the DOM update doesn't flow back to you. `.agent` is a typed JSON document where you write only the **data**. A conformant renderer (the web viewer, Tsuzuri, future MCP Apps server) turns that data into a rich interactive UI the user can edit. Next turn, you re-read the JSON and see the user's edits.
+HTML artifacts for dashboards are verbose (hundreds of lines of markup), static, and round-trip-lossy — if the user drags a kanban card, the DOM update doesn't flow back to you. `.agent` is a typed JSON document where you write only the **data**. A conformant renderer (the web viewer, the `@agent-format/mcp` server for inline Claude / Cursor / VS Code Copilot rendering, or any third-party implementation) turns that data into a rich interactive UI the user can edit. Next turn, you re-read the JSON and see the user's edits.
 
 ## When to reach for this
 

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+.vscode/
+.idea/
+*.tsbuildinfo

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,44 @@
+# @agent-format/cli
+
+Command-line validator for [`.agent` files](https://github.com/knorq-ai/agent-format).
+
+Validates one or more files against the v0.1 JSON Schema. Independent of
+the React renderer — useful in CI, pre-commit hooks, and scripts.
+
+## Install
+
+```bash
+npm install -g @agent-format/cli
+```
+
+## Usage
+
+```bash
+agent-format path/to/file.agent
+agent-format examples/*.agent
+agent-format --quiet ci-fixtures/*.agent    # silent on success
+agent-format --first-error-only broken.agent
+agent-format --version
+```
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| 0 | All files validated |
+| 1 | At least one file failed validation |
+| 2 | Usage error (bad flag, missing files) |
+
+## Why this package exists
+
+Format specs tend to get written as "whatever the reference implementation
+does." That's brittle: the schema becomes advisory, not normative.
+
+`@agent-format/cli` is a second, independent implementation that consumes
+the same `schemas/agent.schema.json` without importing the TS renderer. If
+a writer's output validates here and breaks in the renderer (or vice
+versa), one of the two is wrong — and the schema is the tiebreaker.
+
+## License
+
+MIT.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,8 @@
   ],
   "scripts": {
     "build": "tsc && cp ../../schemas/agent.schema.json dist/agent.schema.json && chmod +x dist/cli.js",
+    "pretest": "npm run build",
+    "test": "vitest run tests/cli.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@agent-format/cli",
+  "version": "0.1.0",
+  "description": "CLI validator for .agent files — a minimal, React-free reference implementation of the agent-format v0.1 schema.",
+  "license": "MIT",
+  "author": "Yuya Morita",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/knorq-ai/agent-format.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/knorq-ai/agent-format/tree/main/packages/cli",
+  "bin": {
+    "agent-format": "dist/cli.js"
+  },
+  "main": "./dist/cli.js",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc && cp ../../schemas/agent.schema.json dist/agent.schema.json && chmod +x dist/cli.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ajv": "^8.17.0",
+    "ajv-formats": "^3.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0"
+  },
+  "keywords": [
+    "agent-format",
+    "cli",
+    "validator",
+    "json-schema"
+  ]
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// `agent-format` — minimal CLI validator for .agent files.
+//
+// This is a deliberately small, React-free, bundler-free second
+// implementation of the v0.1 conformance surface. Its only job is to tell
+// you whether a file validates against `schemas/agent.schema.json`. Having
+// a second implementation is important for a format spec because it proves
+// the schema — not the TypeScript renderer — is the normative contract.
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const requireCjs = createRequire(import.meta.url)
+
+// ajv / ajv-formats ship CJS defaults; reach the runtime constructor via
+// createRequire so NodeNext ESM resolution doesn't fight us.
+type AjvErrorsEntry = { instancePath?: string; message?: string; schemaPath?: string }
+type ValidateFn = {
+    (data: unknown): boolean
+    errors?: AjvErrorsEntry[] | null
+}
+const Ajv2020: new (opts?: unknown) => {
+    compile: (schema: unknown) => ValidateFn
+} = requireCjs('ajv/dist/2020').default
+const addFormats: (ajv: unknown) => void = requireCjs('ajv-formats').default
+
+const SCHEMA_PATH = path.join(__dirname, 'agent.schema.json')
+
+interface Args {
+    files: string[]
+    help: boolean
+    version: boolean
+    allErrors: boolean
+    quiet: boolean
+}
+
+function parseArgs(argv: string[]): Args {
+    const out: Args = {
+        files: [],
+        help: false,
+        version: false,
+        allErrors: true,
+        quiet: false,
+    }
+    for (const a of argv) {
+        if (a === '-h' || a === '--help') out.help = true
+        else if (a === '-v' || a === '--version') out.version = true
+        else if (a === '--first-error-only') out.allErrors = false
+        else if (a === '-q' || a === '--quiet') out.quiet = true
+        else if (a.startsWith('-')) {
+            console.error(`Unknown flag: ${a}`)
+            process.exit(2)
+        } else {
+            out.files.push(a)
+        }
+    }
+    return out
+}
+
+function usage(): string {
+    return [
+        'Usage: agent-format <file.agent> [file.agent ...]',
+        '',
+        'Validates one or more .agent files against the v0.1 JSON Schema.',
+        'Exit 0 on success; exit 1 if any file fails validation; exit 2 for usage errors.',
+        '',
+        'Options:',
+        '  -h, --help              Show this help and exit.',
+        '  -v, --version           Print the CLI version and schema $id.',
+        '  --first-error-only      Stop at the first validation error per file.',
+        '  -q, --quiet             Only print paths of failing files.',
+    ].join('\n')
+}
+
+function loadSchema(): { schema: unknown; id: string } {
+    const raw = fs.readFileSync(SCHEMA_PATH, 'utf8')
+    const schema = JSON.parse(raw) as { $id?: string }
+    const id = typeof schema.$id === 'string' ? schema.$id : '(missing $id)'
+    return { schema, id }
+}
+
+function pkgVersion(): string {
+    const pkg = JSON.parse(
+        fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
+    ) as { version?: string }
+    return pkg.version ?? '0.0.0'
+}
+
+function formatError(e: AjvErrorsEntry): string {
+    const path = e.instancePath || '/'
+    return `  ${path}: ${e.message ?? 'invalid'}`
+}
+
+async function main(): Promise<void> {
+    const args = parseArgs(process.argv.slice(2))
+    if (args.help) {
+        process.stdout.write(usage() + '\n')
+        return
+    }
+    if (args.version) {
+        const { id } = loadSchema()
+        process.stdout.write(`agent-format ${pkgVersion()} — schema ${id}\n`)
+        return
+    }
+    if (args.files.length === 0) {
+        process.stderr.write(usage() + '\n')
+        process.exit(2)
+    }
+
+    const { schema } = loadSchema()
+    const ajv = new Ajv2020({ allErrors: args.allErrors, strict: false })
+    addFormats(ajv)
+    const validate = ajv.compile(schema)
+
+    let fails = 0
+    for (const file of args.files) {
+        const resolved = path.resolve(file)
+        if (path.extname(resolved).toLowerCase() !== '.agent') {
+            fails++
+            process.stderr.write(
+                `✗ ${file}: wrong extension (expected .agent)\n`
+            )
+            continue
+        }
+        let data: unknown
+        try {
+            data = JSON.parse(fs.readFileSync(resolved, 'utf8'))
+        } catch (err) {
+            fails++
+            process.stderr.write(
+                `✗ ${file}: not valid JSON — ${(err as Error).message}\n`
+            )
+            continue
+        }
+        if (validate(data)) {
+            if (!args.quiet) process.stdout.write(`✓ ${file}\n`)
+        } else {
+            fails++
+            process.stderr.write(`✗ ${file}\n`)
+            if (!args.quiet) {
+                for (const e of validate.errors ?? []) {
+                    process.stderr.write(formatError(e) + '\n')
+                }
+            }
+        }
+    }
+    process.exit(fails === 0 ? 0 : 1)
+}
+
+main().catch((err) => {
+    process.stderr.write(`agent-format CLI crashed: ${String(err)}\n`)
+    process.exit(2)
+})

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -1,0 +1,147 @@
+// End-to-end: compiles the CLI, runs it against the repo's example files
+// (expect pass) and crafted negative fixtures (expect fail). This both
+// exercises the CLI binary and — because the CLI uses its own Ajv instance
+// against the shared schema — serves as a cross-check on the renderer's
+// interpretation of the format.
+import { describe, expect, it, beforeAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
+const CLI = path.join(REPO_ROOT, 'packages', 'cli', 'dist', 'cli.js')
+const EXAMPLES = path.join(REPO_ROOT, 'examples')
+
+function run(args: string[]): { status: number; stdout: string; stderr: string } {
+    try {
+        const stdout = execFileSync('node', [CLI, ...args], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+        })
+        return { status: 0, stdout, stderr: '' }
+    } catch (e) {
+        const err = e as { status?: number; stdout?: Buffer; stderr?: Buffer }
+        return {
+            status: err.status ?? 1,
+            stdout: err.stdout?.toString() ?? '',
+            stderr: err.stderr?.toString() ?? '',
+        }
+    }
+}
+
+describe('@agent-format/cli', () => {
+    beforeAll(() => {
+        if (!fs.existsSync(CLI)) {
+            throw new Error(
+                `CLI binary missing at ${CLI}. Run \`npm run build -w @agent-format/cli\` before tests.`
+            )
+        }
+    })
+
+    it('prints --help without erroring', () => {
+        const r = run(['--help'])
+        expect(r.status).toBe(0)
+        expect(r.stdout).toContain('Usage: agent-format')
+    })
+
+    it('exit 2 when called with no files', () => {
+        const r = run([])
+        expect(r.status).toBe(2)
+    })
+
+    it('validates all committed examples', () => {
+        const files = fs
+            .readdirSync(EXAMPLES)
+            .filter((f) => f.endsWith('.agent'))
+            .map((f) => path.join(EXAMPLES, f))
+        expect(files.length).toBeGreaterThan(0)
+        const r = run(files)
+        if (r.status !== 0) {
+            throw new Error(`expected 0 exit, got ${r.status}\n${r.stderr}`)
+        }
+        expect(r.stdout).toContain('✓')
+    })
+
+    it('rejects a malformed agent file', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const bad = path.join(tmp, 'bad.agent')
+        // Missing required `sections` / `memory` / `config`.
+        fs.writeFileSync(bad, JSON.stringify({ version: '0.1', name: 'x' }))
+        const r = run([bad])
+        expect(r.status).toBe(1)
+        expect(r.stderr).toContain('✗')
+    })
+
+    it('rejects a file with the wrong extension', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const wrongExt = path.join(tmp, 'file.json')
+        fs.writeFileSync(wrongExt, JSON.stringify({}))
+        const r = run([wrongExt])
+        expect(r.status).toBe(1)
+        expect(r.stderr.toLowerCase()).toContain('wrong extension')
+    })
+
+    it('rejects invalid JSON with a non-crash error', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const bad = path.join(tmp, 'bad.agent')
+        fs.writeFileSync(bad, '{not json')
+        const r = run([bad])
+        expect(r.status).toBe(1)
+        expect(r.stderr).toContain('not valid JSON')
+    })
+
+    it('rejects unknown bare section type (enforces x-<vendor>:<name>)', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const bad = path.join(tmp, 'custom.agent')
+        fs.writeFileSync(
+            bad,
+            JSON.stringify({
+                version: '0.1',
+                name: 'x',
+                createdAt: '2026-04-20T00:00:00Z',
+                updatedAt: '2026-04-20T00:00:00Z',
+                config: { proactive: false },
+                memory: { observations: [], preferences: {} },
+                sections: [
+                    {
+                        id: 's1',
+                        type: 'made-up-widget',
+                        label: 'x',
+                        order: 0,
+                        data: {},
+                    },
+                ],
+            })
+        )
+        const r = run([bad])
+        expect(r.status).toBe(1)
+    })
+
+    it('accepts x-<vendor>:<name> extension section (§ 7.2)', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const ok = path.join(tmp, 'ext.agent')
+        fs.writeFileSync(
+            ok,
+            JSON.stringify({
+                version: '0.1',
+                name: 'x',
+                createdAt: '2026-04-20T00:00:00Z',
+                updatedAt: '2026-04-20T00:00:00Z',
+                config: { proactive: false },
+                memory: { observations: [], preferences: {} },
+                sections: [
+                    {
+                        id: 's1',
+                        type: 'x-acme:burndown',
+                        label: 'Burndown',
+                        order: 0,
+                        data: { any: 'shape' },
+                    },
+                ],
+            })
+        )
+        const r = run([ok])
+        expect(r.status).toBe(0)
+    })
+})

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": false,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -96,9 +96,8 @@ Claude generates the `.agent` JSON, calls `render_agent_inline` with it, and the
 
 - The server is a stdio-based MCP server using `@modelcontextprotocol/sdk` and `@modelcontextprotocol/ext-apps`.
 - Tools declare a shared UI resource URI `ui://agent-format/render.html`.
-- The UI resource is a tiny HTML shell that iframes the deployed viewer at `knorq-ai.github.io/agent-format/` with the agent JSON encoded in the URL hash.
-- CSP `frameDomains` allows that origin.
-- When the tool result arrives via the MCP Apps `ui/notifications/tool-result` postMessage, the shell reads the `structuredContent.data` and points the iframe at the viewer.
+- The UI resource is a single self-contained HTML document: the `@agent-format/renderer` React bundle and CSS are inlined at build time (see `build-ui.mjs`). No nested iframes, no external fetches, no CSP `frameDomains` required — the default sandbox is sufficient.
+- When the tool result arrives via the MCP Apps `ui/notifications/tool-result` postMessage, the embedded script reads `structuredContent.data` and mounts `<AgentRenderer/>` against it directly.
 
 This means the visual output is identical to what you'd see on the standalone viewer — same React renderer, same CSS — just embedded in the chat.
 

--- a/packages/mcp/build-ui.mjs
+++ b/packages/mcp/build-ui.mjs
@@ -11,6 +11,14 @@ import { createRequire } from 'node:module'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const require = createRequire(import.meta.url)
 
+// Read the package version from our own package.json so the App version
+// reported to the MCP Apps host matches the published npm version exactly.
+// Avoids the prior foot-gun of a hand-edited string in ui-client.tsx drifting
+// behind package.json after a release bump.
+const pkg = JSON.parse(
+    await fs.readFile(path.join(__dirname, 'package.json'), 'utf8')
+)
+
 const result = await esbuild.build({
     entryPoints: [path.join(__dirname, 'src/ui-client.tsx')],
     bundle: true,
@@ -20,7 +28,10 @@ const result = await esbuild.build({
     minify: true,
     jsx: 'automatic',
     outfile: path.join(__dirname, 'dist/ui-client.js'),
-    define: { 'process.env.NODE_ENV': '"production"' },
+    define: {
+        'process.env.NODE_ENV': '"production"',
+        __APP_VERSION__: JSON.stringify(pkg.version),
+    },
     logLevel: 'info',
 })
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -21,15 +21,17 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc && node build-ui.mjs && chmod +x dist/server.js",
+    "build": "tsc && node build-ui.mjs && cp ../../schemas/agent.schema.json dist/agent.schema.json && chmod +x dist/server.js",
     "dev": "tsc --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.ui.json"
   },
   "dependencies": {
-    "@agent-format/jp-court": "^0.1.2",
-    "@agent-format/renderer": "^0.1.5",
+    "@agent-format/jp-court": "0.1.2",
+    "@agent-format/renderer": "0.1.5",
     "@modelcontextprotocol/ext-apps": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "ajv": "^8.17.0",
+    "ajv-formats": "^3.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^3.23.0"

--- a/packages/mcp/src/resolve.ts
+++ b/packages/mcp/src/resolve.ts
@@ -41,6 +41,13 @@ export async function resolveAgentFile(
         readFile: typeof fs.readFile
     } = fs
 ): Promise<ResolveResult> {
+    if (!path.isAbsolute(filePath)) {
+        return {
+            ok: false,
+            message: 'filePath must be an absolute path',
+        }
+    }
+
     const resolved = path.resolve(filePath)
     const base = path.basename(resolved)
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -11,6 +11,19 @@ import { z } from 'zod'
 import * as fsSync from 'node:fs'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
+// ajv and ajv-formats ship CJS defaults; NodeNext ESM resolution surfaces
+// them via `.default`. Use createRequire to reach the runtime constructor
+// without fighting the type system.
+import { createRequire } from 'node:module'
+const requireCjs = createRequire(import.meta.url)
+const Ajv2020: new (opts?: unknown) => {
+    compile: (schema: unknown) => ValidateFunction
+} = requireCjs('ajv/dist/2020').default
+const addFormats: (ajv: unknown) => void = requireCjs('ajv-formats').default
+interface ValidateFunction {
+    (data: unknown): boolean
+    errors?: { instancePath?: string; message?: string }[] | null
+}
 import { isAgentLike, resolveAgentFile } from './resolve.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -27,6 +40,28 @@ const UI_URI = 'ui://agent-format/render.html'
 // @agent-format/renderer into a single IIFE, plus the renderer's CSS.
 const UI_CLIENT_JS = fsSync.readFileSync(path.join(__dirname, 'ui-client.js'), 'utf8')
 const UI_STYLES_CSS = fsSync.readFileSync(path.join(__dirname, 'ui-styles.css'), 'utf8')
+
+// JSON Schema for full-document validation of inline payloads. Copied from
+// schemas/agent.schema.json at build time (see tsconfig `resolveJsonModule`).
+// We compile once at startup; validation is a hot path on every tool call.
+const agentSchema = JSON.parse(
+    fsSync.readFileSync(path.join(__dirname, 'agent.schema.json'), 'utf8')
+)
+// allErrors: true — so `summarizeAjvErrors` can pick the most informative
+// of several parallel failures (e.g. a single bad section triggers both a
+// `const` mismatch on `type` and a `oneOf` failure at the parent array).
+const ajv = new Ajv2020({ allErrors: true, strict: false })
+addFormats(ajv)
+const validateAgent = ajv.compile(agentSchema)
+
+function summarizeAjvErrors(errs: ValidateFunction['errors']): string {
+    if (!errs || errs.length === 0) return 'unknown validation failure'
+    // Return the first two errors only — full dumps are noisy for model consumption.
+    return errs
+        .slice(0, 2)
+        .map((e) => `${e.instancePath || '/'} ${e.message ?? 'invalid'}`)
+        .join('; ')
+}
 
 const RENDER_HTML = `<!doctype html>
 <html lang="en">
@@ -125,6 +160,20 @@ registerAppTool(
                     {
                         type: 'text',
                         text: 'The `data` argument is not a valid .agent document (missing or non-array `sections`).',
+                    },
+                ],
+                isError: true,
+            }
+        }
+        // Full JSON-Schema validation: reject malformed documents up front so
+        // the UI iframe never tries to render garbage. Keep the message short
+        // (first couple of errors) so models can self-correct without a flood.
+        if (!validateAgent(data)) {
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: `Invalid .agent document: ${summarizeAjvErrors(validateAgent.errors)}`,
                     },
                 ],
                 isError: true,

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -117,6 +117,9 @@ registerAppTool(
                     isError: true,
                 }
             }
+            if (!validateAgent(result.data)) {
+                return invalidAgentResult(validateAgent.errors)
+            }
             return {
                 content: [{ type: 'text', text: result.message }],
                 structuredContent: { data: result.data } as Record<string, unknown>,
@@ -169,15 +172,7 @@ registerAppTool(
         // the UI iframe never tries to render garbage. Keep the message short
         // (first couple of errors) so models can self-correct without a flood.
         if (!validateAgent(data)) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Invalid .agent document: ${summarizeAjvErrors(validateAgent.errors)}`,
-                    },
-                ],
-                isError: true,
-            }
+            return invalidAgentResult(validateAgent.errors)
         }
         const name = typeof data.name === 'string' ? data.name : 'agent data'
         return {
@@ -219,6 +214,18 @@ registerAppResource(
 async function main(): Promise<void> {
     const transport = new StdioServerTransport()
     await server.connect(transport)
+}
+
+function invalidAgentResult(errors: ValidateFunction['errors']): CallToolResult {
+    return {
+        content: [
+            {
+                type: 'text',
+                text: `Invalid .agent document: ${summarizeAjvErrors(errors)}`,
+            },
+        ],
+        isError: true,
+    }
 }
 
 main().catch((err) => {

--- a/packages/mcp/src/ui-client.tsx
+++ b/packages/mcp/src/ui-client.tsx
@@ -40,7 +40,7 @@ function showEmpty(text: string) {
     if (mount) mount.style.display = 'none'
 }
 
-const app = new App({ name: 'agent-format-renderer', version: '0.1.3' })
+const app = new App({ name: 'agent-format-renderer', version: __APP_VERSION__ })
 
 // Bridge from renderer's generic HostBridge interface to the MCP Apps SDK.
 // The sandbox blocks window.open() and anchor downloads directly; the app
@@ -53,19 +53,16 @@ const hostBridge: HostBridge = {
     },
     downloadFile: async ({ mimeType, text, blobBase64, filename }) => {
         // Prefer text when provided (HTML/JSON/CSV). Use blob (base64) for
-        // binary payloads.
-        const resource: {
-            uri: string
-            mimeType: string
-            text?: string
-            blob?: string
-        } = {
-            uri: `file:///${filename}`,
-            mimeType,
-        }
-        if (typeof text === 'string') resource.text = text
-        else if (typeof blobBase64 === 'string') resource.blob = blobBase64
-        else return false
+        // binary payloads. The SDK types resource as a discriminated union
+        // so build each branch separately rather than mutating a shared object.
+        const uri = `file:///${filename}`
+        const resource =
+            typeof text === 'string'
+                ? { uri, mimeType, text }
+                : typeof blobBase64 === 'string'
+                    ? { uri, mimeType, blob: blobBase64 }
+                    : null
+        if (!resource) return false
         const { isError } = await app.downloadFile({
             contents: [{ type: 'resource', resource }],
         })

--- a/packages/mcp/src/ui-env.d.ts
+++ b/packages/mcp/src/ui-env.d.ts
@@ -1,0 +1,4 @@
+// Build-time constant injected by build-ui.mjs via esbuild `define`.
+// Sourced from packages/mcp/package.json so the MCP App version stays in
+// lockstep with the npm package — no hand-edits, no drift.
+declare const __APP_VERSION__: string

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -35,6 +35,12 @@ describe('resolveAgentFile', () => {
         expect(r.sectionCount).toBe(0)
     })
 
+    it('rejects a relative path before touching the filesystem', async () => {
+        const r = await resolveAgentFile('relative.agent')
+        expect(r.ok).toBe(false)
+        expect(r.message).toBe('filePath must be an absolute path')
+    })
+
     it('rejects a non-.agent extension (XYZ.txt, .json)', async () => {
         const p = path.join(tmp, 'x.json')
         await fs.writeFile(p, JSON.stringify(VALID_AGENT))

--- a/packages/mcp/tsconfig.ui.json
+++ b/packages/mcp/tsconfig.ui.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "noEmit": true
+  },
+  "include": ["src/ui-client.tsx", "src/ui-env.d.ts"]
+}

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -35,13 +35,13 @@ All 12 v0.1 section types are implemented:
 |---|---|
 | `kanban` | Status-column board with cards, labels, WIP limits |
 | `checklist` | Grouped todo items with progress counts |
-| `notes` | Ordered markdown blocks |
+| `notes` | Ordered plain-text blocks (newlines preserved) |
 | `timeline` | Items + milestones with dates |
 | `table` | Rows with typed columns (text / number / date / select / status) |
 | `log` | Risks, decisions, issues with badges |
 | `metrics` | KPI cards with value / unit / trend |
 | `diagram` | Nested tree (mind map / hierarchy) |
-| `report` | Repeating markdown reports |
+| `report` | Repeating plain-text reports (newlines preserved) |
 | `form` | Input fields + submission count |
 | `links` | URL list grouped by category |
 | `references` | File references with memos |

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -29,7 +29,7 @@ export default function Page({ data }: { data: AgentFile }) {
 
 ## Section support (v0.1)
 
-All 12 v0.1 section types are implemented:
+The renderer supports 13 built-in section types, plus the deprecated `inheritance-diagram` alias and `x-<vendor>:<name>` extension sections:
 
 | Type | Use for |
 |---|---|
@@ -45,6 +45,9 @@ All 12 v0.1 section types are implemented:
 | `form` | Input fields + submission count |
 | `links` | URL list grouped by category |
 | `references` | File references with memos |
+| `family-graph` | Genealogy / inheritance diagrams, including plugin variants |
+| `inheritance-diagram` | Deprecated alias for `family-graph` |
+| `x-<vendor>:<name>` | Extension sections rendered by plugins or fallback UI |
 
 Unknown section types render as a fallback showing the raw JSON, per the spec's conformance rule that readers MUST NOT error on unknown section types.
 

--- a/packages/renderer/src/actions.ts
+++ b/packages/renderer/src/actions.ts
@@ -15,6 +15,32 @@ import { sanitizeSvgForEmbed } from './sanitize'
 // viewer versions (renders the data client-side, no upload).
 const VIEWER_URL = 'https://knorq-ai.github.io/agent-format/'
 
+const VALID_PAGE_SIZES = new Map<string, string>([
+    ['a5', 'A5'],
+    ['a5 landscape', 'A5 landscape'],
+    ['a4', 'A4'],
+    ['a4 landscape', 'A4 landscape'],
+    ['a3', 'A3'],
+    ['a3 landscape', 'A3 landscape'],
+    ['b5', 'B5'],
+    ['b5 landscape', 'B5 landscape'],
+    ['b4', 'B4'],
+    ['b4 landscape', 'B4 landscape'],
+    ['letter', 'Letter'],
+    ['letter landscape', 'Letter landscape'],
+    ['legal', 'Legal'],
+    ['legal landscape', 'Legal landscape'],
+    ['ledger', 'Ledger'],
+    ['ledger landscape', 'Ledger landscape'],
+    ['tabloid', 'Tabloid'],
+    ['tabloid landscape', 'Tabloid landscape'],
+])
+
+const CUSTOM_PAGE_SIZE_RE = /^[\d.]+(mm|cm|in|pt|px)\s+[\d.]+(mm|cm|in|pt|px)$/i
+const PAGE_MARGIN_RE = /^(\d+(\.\d+)?(mm|cm|in|pt|px)\s*){1,4}$/i
+const INVALID_FONT_FAMILY_RE = /[^A-Za-z0-9 ,'"-]/
+const BLOCKED_FONT_FAMILY_RE = /{|}|<|>|;|\/\*|\*\/|@/
+
 export async function openInViewer(
     data: AgentFile,
     host?: HostBridge
@@ -51,6 +77,9 @@ export function buildPrintableHtml({
     const safeTitle = escapeHtml(documentTitle)
     const safeLabel = escapeHtml(titleLabel)
     const safeSvg = sanitizeSvgForEmbed(svgMarkup)
+    const safePageSize = sanitizePageSize(pageSize)
+    const safeMargin = sanitizeMargin(margin)
+    const safeFontFamily = sanitizeFontFamily(fontFamily)
     const autoPrintScript = autoPrint
         ? `<script>window.addEventListener('load', () => setTimeout(() => window.print(), 250));</script>`
         : ''
@@ -58,9 +87,9 @@ export function buildPrintableHtml({
 <meta charset="utf-8">
 <title>${safeTitle}</title>
 <style>
-  @page { size: ${pageSize}; margin: ${margin}; }
+  @page { size: ${safePageSize}; margin: ${safeMargin}; }
   * { box-sizing: border-box; }
-  body { font-family: ${fontFamily}; margin: 0; padding: 24px 40px; background: #fff; color: #000; }
+  body { font-family: ${safeFontFamily}; margin: 0; padding: 24px 40px; background: #fff; color: #000; }
   .doc-title {
     text-align: center;
     font-size: 16pt;
@@ -69,7 +98,7 @@ export function buildPrintableHtml({
     margin: 0 0 36px;
   }
   svg { display: block; width: 100%; max-width: 1400px; margin: 0 auto; overflow: visible; }
-  svg text { font-family: ${fontFamily}; }
+  svg text { font-family: ${safeFontFamily}; }
   @media print { .toolbar { display: none !important; } }
   .toolbar { position: fixed; top: 8px; right: 12px; font-family: sans-serif; font-size: 12px; color: #666; }
 </style>
@@ -120,4 +149,28 @@ function escapeHtml(s: string): string {
     return s.replace(/[&<>"']/g, (c) =>
         c === '&' ? '&amp;' : c === '<' ? '&lt;' : c === '>' ? '&gt;' : c === '"' ? '&quot;' : '&#39;'
     )
+}
+
+function sanitizePageSize(pageSize: string): string {
+    const normalized = pageSize.trim().toLowerCase().replace(/\s+/g, ' ')
+    if (VALID_PAGE_SIZES.has(normalized)) return VALID_PAGE_SIZES.get(normalized) as string
+    if (CUSTOM_PAGE_SIZE_RE.test(pageSize.trim())) return pageSize.trim()
+    return 'A4'
+}
+
+function sanitizeMargin(margin: string): string {
+    const normalized = margin.trim()
+    return PAGE_MARGIN_RE.test(normalized) ? normalized : '20mm'
+}
+
+function sanitizeFontFamily(fontFamily: string): string {
+    const normalized = fontFamily.trim()
+    if (
+        !normalized ||
+        BLOCKED_FONT_FAMILY_RE.test(normalized) ||
+        INVALID_FONT_FAMILY_RE.test(normalized)
+    ) {
+        return 'sans-serif'
+    }
+    return normalized
 }

--- a/packages/renderer/src/actions.ts
+++ b/packages/renderer/src/actions.ts
@@ -8,6 +8,7 @@
 
 import type { AgentFile } from './types'
 import { type HostBridge, fallbackOpenLink, fallbackDownload } from './host'
+import { sanitizeSvgForEmbed } from './sanitize'
 
 // Public viewer endpoint for the `.agent` format. The `#<encoded-json>` hash
 // form is documented in packages/viewer/src/App.tsx and stable across
@@ -49,6 +50,7 @@ export function buildPrintableHtml({
 }): string {
     const safeTitle = escapeHtml(documentTitle)
     const safeLabel = escapeHtml(titleLabel)
+    const safeSvg = sanitizeSvgForEmbed(svgMarkup)
     const autoPrintScript = autoPrint
         ? `<script>window.addEventListener('load', () => setTimeout(() => window.print(), 250));</script>`
         : ''
@@ -74,7 +76,7 @@ export function buildPrintableHtml({
 </head><body>
 <div class="toolbar">⌘P で印刷 / PDF 保存</div>
 <h1 class="doc-title">${safeLabel}</h1>
-${svgMarkup}
+${safeSvg}
 ${autoPrintScript}
 </body></html>`
 }

--- a/packages/renderer/src/index.tsx
+++ b/packages/renderer/src/index.tsx
@@ -17,17 +17,34 @@ import { FamilyGraphSectionView } from './sections/FamilyGraphSection'
 import { FallbackSectionView } from './sections/Fallback'
 import { openInViewer } from './actions'
 import type { HostBridge } from './host'
-import type { RendererPlugin } from './plugins'
+import { findSectionComponent, type RendererPlugin } from './plugins'
 
 export * from './types'
 export type { HostBridge } from './host'
 export type { RendererPlugin, VariantRendererProps, VariantComponent } from './plugins'
-export { findVariantComponent } from './plugins'
+export { findVariantComponent, findSectionComponent } from './plugins'
 export {
     openInViewer,
     buildPrintableHtml,
     downloadPrintableHtml,
 } from './actions'
+export { sanitizeSvgForEmbed } from './sanitize'
+
+// Spec major version this renderer is built against. Documents whose
+// `version` major exceeds this are rendered with a warning banner; the
+// renderer still best-effort renders the sections it recognizes, per
+// spec § 3.1 ("reject unknown major versions OR degrade gracefully with
+// a warning").
+export const SPEC_MAJOR = 0
+
+function parseVersionMajor(v: unknown): number | null {
+    // Strict: require semver-ish `MAJOR.MINOR(.PATCH)?(-prerelease)?` with
+    // purely numeric MAJOR and no leading `v`. Anything else returns null,
+    // which the caller treats as "unknown but don't warn" (back-compat).
+    if (typeof v !== 'string') return null
+    const m = /^(\d+)\.\d+(?:\.\d+)?(?:-[A-Za-z0-9.-]+)?$/.exec(v)
+    return m ? Number(m[1]) : null
+}
 
 const HostContext = createContext<HostBridge | undefined>(undefined)
 const PluginsContext = createContext<ReadonlyArray<RendererPlugin>>([])
@@ -75,11 +92,32 @@ export function AgentRenderer({
     plugins = [],
 }: AgentRendererProps) {
     const sections = [...data.sections].sort((a, b) => a.order - b.order)
+    const docMajor = parseVersionMajor(data.version)
+    const unsupportedMajor = docMajor !== null && docMajor > SPEC_MAJOR
 
     return (
         <HostContext.Provider value={host}>
             <PluginsContext.Provider value={plugins}>
                 <div className={`af-root ${className ?? ''}`}>
+                    {unsupportedMajor && (
+                        <div
+                            className="af-version-warning"
+                            role="alert"
+                            style={{
+                                padding: '8px 12px',
+                                margin: '0 0 12px',
+                                border: '1px solid #d97706',
+                                background: '#fffbeb',
+                                color: '#78350f',
+                                borderRadius: 6,
+                                font: '13px -apple-system, system-ui, sans-serif',
+                            }}
+                        >
+                            Document declares spec version {String(data.version)};
+                            this renderer supports {SPEC_MAJOR}.x. Rendering with
+                            best-effort fallbacks — unknown fields may be ignored.
+                        </div>
+                    )}
                     <header className="af-header">
                         <div className="af-header-main">
                             <h1 className="af-title">
@@ -122,6 +160,8 @@ export function AgentRenderer({
 
 function SectionFrame({ section }: { section: Section }) {
     const [actions, setActions] = useState<ReactElement | null>(null)
+    const plugins = useContext(PluginsContext)
+    const PluginView = findSectionComponent(plugins, section.type)
     return (
         <section className="af-section">
             <header className="af-section-header">
@@ -134,7 +174,11 @@ function SectionFrame({ section }: { section: Section }) {
                 )}
             </header>
             <div className="af-section-body">
-                <SectionRenderer section={section} setHeaderActions={setActions} />
+                {PluginView ? (
+                    <PluginView section={section} setHeaderActions={setActions} />
+                ) : (
+                    <SectionRenderer section={section} setHeaderActions={setActions} />
+                )}
             </div>
         </section>
     )

--- a/packages/renderer/src/plugins.ts
+++ b/packages/renderer/src/plugins.ts
@@ -34,6 +34,36 @@ export interface RendererPlugin {
      *   }
      */
     variants?: Partial<Record<SectionType | string, Record<string, VariantComponent>>>
+    /**
+     * Top-level renderers for namespaced extension section types
+     * (`x-<vendor>:<name>`, see spec § 7.2). Keys are section `type`
+     * strings; values are the component to mount. Example:
+     *
+     *   {
+     *     'x-acme:burndown-chart': BurndownChartView,
+     *   }
+     *
+     * Unlike `variants`, this claims ownership of the whole section type.
+     * Only matches when the incoming section's `type` equals the key
+     * literally; lookup is first-plugin-wins across the supplied list.
+     */
+    sections?: Record<string, VariantComponent>
+}
+
+/**
+ * Walk the supplied plugin list in order and return the first registered
+ * top-level renderer for an extension section type, or undefined if none
+ * claims it. Used by `AgentRenderer` to route `x-<vendor>:<name>` sections.
+ */
+export function findSectionComponent(
+    plugins: ReadonlyArray<RendererPlugin>,
+    sectionType: string
+): VariantComponent | undefined {
+    for (const plugin of plugins) {
+        const component = plugin.sections?.[sectionType]
+        if (component) return component
+    }
+    return undefined
 }
 
 /**

--- a/packages/renderer/src/plugins.ts
+++ b/packages/renderer/src/plugins.ts
@@ -4,7 +4,7 @@
 // AgentRenderer internals.
 
 import type { ComponentType, ReactElement } from 'react'
-import type { Section, SectionType } from './types'
+import type { ExtensionSectionType, Section, SectionType } from './types'
 
 export interface VariantRendererProps<S extends Section = Section> {
     section: S
@@ -47,7 +47,7 @@ export interface RendererPlugin {
      * Only matches when the incoming section's `type` equals the key
      * literally; lookup is first-plugin-wins across the supplied list.
      */
-    sections?: Record<string, VariantComponent>
+    sections?: Partial<Record<ExtensionSectionType, VariantComponent>>
 }
 
 /**
@@ -59,8 +59,16 @@ export function findSectionComponent(
     plugins: ReadonlyArray<RendererPlugin>,
     sectionType: string
 ): VariantComponent | undefined {
+    // Callers pass `section.type` which is a plain string at runtime; the
+    // `sections` map is typed as `Partial<Record<ExtensionSectionType, …>>`
+    // (template-literal keys) so indexing with a raw string fails typecheck.
+    // Reading via a widened record view is safe — we never *write* through
+    // this reference, and a non-extension key simply returns undefined.
     for (const plugin of plugins) {
-        const component = plugin.sections?.[sectionType]
+        const table = plugin.sections as
+            | Record<string, VariantComponent>
+            | undefined
+        const component = table?.[sectionType]
         if (component) return component
     }
     return undefined

--- a/packages/renderer/src/sanitize.ts
+++ b/packages/renderer/src/sanitize.ts
@@ -1,0 +1,229 @@
+// Defensive sanitizer for SVG strings before they get inlined into HTML we
+// ship to the browser (print/PDF flow) or hand to a third party.
+//
+// Callers include `buildPrintableHtml`, which embeds `svgMarkup` raw into a
+// standalone HTML document. Even though the renderer's own SVG output is
+// trusted today, `svgMarkup` is a public API parameter so any external caller
+// could pass arbitrary untrusted SVG. SVG is an XSS vector: `<script>`,
+// `on*` event handlers, `<style>` with `url(javascript:...)` or `expression()`,
+// `href`/`xlink:href` with `javascript:` (including entity-encoded and
+// whitespace-obfuscated variants), external `<use href>`, and more.
+//
+// Strategy:
+//   1. When a DOMParser is available (browser, happy-dom in tests, jsdom),
+//      parse the SVG and walk the tree with an element/attribute allowlist.
+//      Parsing-based sanitization defeats regex bypasses by construction.
+//   2. If DOMParser is unavailable (bare Node without a DOM polyfill),
+//      fall back to a hardened regex pass. The regex path is intentionally
+//      destructive — prefer false positives over false negatives.
+//
+// This sanitizer is intended as defense in depth. Callers SHOULD still
+// treat SVG input as potentially untrusted and avoid rendering it in
+// security-sensitive contexts without a Content-Security-Policy.
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+// Conservative allowlist. Drop anything we don't positively know to be safe.
+const ALLOWED_TAGS = new Set([
+    'svg', 'g', 'defs', 'title', 'desc',
+    'path', 'rect', 'circle', 'ellipse', 'line', 'polyline', 'polygon',
+    'text', 'tspan', 'textPath',
+    'marker', 'symbol', 'clipPath', 'mask', 'pattern',
+    'linearGradient', 'radialGradient', 'stop',
+    'filter', 'feBlend', 'feColorMatrix', 'feComponentTransfer',
+    'feComposite', 'feConvolveMatrix', 'feDiffuseLighting',
+    'feDisplacementMap', 'feFlood', 'feGaussianBlur', 'feMerge',
+    'feMergeNode', 'feMorphology', 'feOffset', 'feSpecularLighting',
+    'feTile', 'feTurbulence', 'feFuncA', 'feFuncR', 'feFuncG', 'feFuncB',
+    'a', 'use',
+])
+
+// Denied outright — even if they happen to slip past tag lowercasing.
+// SMIL animation elements are denied because `<animate to="javascript:...">`
+// can hijack a permitted `href` attribute at runtime on real browsers.
+const DENIED_TAGS = new Set([
+    'script', 'style', 'foreignobject', 'foreignObject',
+    'iframe', 'object', 'embed', 'image', 'animation',
+    'animate', 'animateTransform', 'animateMotion', 'set',
+    'mpath', 'discard', 'audio', 'video', 'canvas',
+])
+
+// `href` / `xlink:href` / `src` / `action` are scrubbed via url policy.
+const URL_ATTRS = new Set(['href', 'xlink:href', 'src', 'action', 'formaction'])
+
+function isSafeUrl(raw: string): boolean {
+    if (typeof raw !== 'string') return false
+    // Decode numeric HTML entities so `&#106;avascript:` and
+    // `&#x6a;avascript:` both resolve before we match, defeating the most
+    // common entity-based bypasses. Use separate decimal and hex passes so
+    // the base is never ambiguous (a prior implementation tried to detect
+    // hex via `.match(/^x/i)` on the captured digits-only group and silently
+    // fell through to decimal parsing, leaking `javascript:`).
+    const decoded = raw
+        .replace(/&#x([0-9a-f]+);?/gi, (_m, hex: string) => {
+            const n = parseInt(hex, 16)
+            return Number.isFinite(n) ? String.fromCharCode(n) : ''
+        })
+        .replace(/&#([0-9]+);?/g, (_m, dec: string) => {
+            const n = parseInt(dec, 10)
+            return Number.isFinite(n) ? String.fromCharCode(n) : ''
+        })
+        // Also decode the named entities a browser would resolve inside an
+        // href attribute, because `&colon;` → `:` (etc.) lets an attacker
+        // hide the scheme's colon.
+        .replace(/&colon;/gi, ':')
+        .replace(/&tab;/gi, '\t')
+        .replace(/&newline;/gi, '\n')
+    // Strip control chars (incl. \t, \n, \r, NUL, BOM) before scheme check.
+    // Browsers will canonicalize away these characters in URL schemes, so
+    // `java\tscript:` must be treated the same as `javascript:`.
+    const normalized = decoded.replace(/[\x00-\x1f\x7f\u200b-\u200f\ufeff]/g, '').trimStart()
+    const lower = normalized.toLowerCase()
+    if (/^(?:javascript|vbscript|data|blob|filesystem):/i.test(lower)) return false
+    // Same-document fragments are fine (`#id`). Relative / absolute http(s) fine.
+    if (lower.startsWith('#')) return true
+    if (lower.startsWith('/')) return true
+    if (/^https?:\/\//.test(lower)) return true
+    if (/^mailto:/.test(lower)) return true
+    if (/^tel:/.test(lower)) return true
+    // Schemeless relative (no `:` before first `/` or `?` or `#`) is fine.
+    const firstColon = lower.indexOf(':')
+    const firstSlash = lower.indexOf('/')
+    if (firstColon === -1) return true
+    if (firstSlash !== -1 && firstSlash < firstColon) return true
+    return false
+}
+
+function sanitizeDom(root: Element): void {
+    const walker = root.ownerDocument!.createTreeWalker(root, 0x1 /* NodeFilter.SHOW_ELEMENT */)
+    const toRemove: Element[] = []
+    let node: Node | null = walker.currentNode
+    while (node) {
+        if (node.nodeType === 1) {
+            const el = node as Element
+            const tag = el.localName
+            if (DENIED_TAGS.has(tag.toLowerCase()) || !ALLOWED_TAGS.has(tag)) {
+                toRemove.push(el)
+            } else {
+                for (const attr of Array.from(el.attributes)) {
+                    const name = attr.name.toLowerCase()
+                    // Drop any on* handlers.
+                    if (name.startsWith('on')) {
+                        el.removeAttribute(attr.name)
+                        continue
+                    }
+                    // Drop inline style entirely — it can hide url(javascript:)
+                    // and expression() payloads.
+                    if (name === 'style') {
+                        el.removeAttribute(attr.name)
+                        continue
+                    }
+                    if (URL_ATTRS.has(name)) {
+                        if (!isSafeUrl(attr.value)) {
+                            el.removeAttribute(attr.name)
+                        }
+                    }
+                }
+                // For <use>, only allow same-document fragment references.
+                // SVG parsers vary on whether `xlink:href` ends up under the
+                // XLink namespace or as a qualified-name attribute, so iterate
+                // all attributes and strip any href-ish one whose value isn't
+                // a local fragment.
+                if (tag === 'use') {
+                    for (const a of Array.from(el.attributes)) {
+                        const n = a.name.toLowerCase()
+                        if ((n === 'href' || n.endsWith(':href')) && !a.value.startsWith('#')) {
+                            el.removeAttributeNode(a)
+                        }
+                    }
+                }
+            }
+        }
+        node = walker.nextNode()
+    }
+    for (const el of toRemove) el.parentNode?.removeChild(el)
+}
+
+// Hardened regex fallback for environments without DOMParser. Intentionally
+// aggressive: we'd rather destroy valid SVG than miss a payload.
+function sanitizeRegex(svg: string): string {
+    let out = svg
+    // Strip anything that looks like a script / style / foreign-object block,
+    // with or without namespace prefixes (handles `<svg:script>`).
+    const blockTags = [
+        'script', 'style', 'foreignObject', 'iframe', 'object', 'embed',
+        // SMIL animation elements can hijack permitted href/src attributes
+        // via `to=`/`values=`/`from=` even if their own attributes look clean.
+        'animate', 'animateTransform', 'animateMotion', 'set', 'mpath', 'discard',
+        'audio', 'video', 'canvas',
+    ]
+    for (const t of blockTags) {
+        const open = new RegExp(`<(?:[\\w-]+:)?${t}\\b[^>]*>[\\s\\S]*?<\\/(?:[\\w-]+:)?${t}\\s*[^>]*>`, 'gi')
+        const selfClose = new RegExp(`<(?:[\\w-]+:)?${t}\\b[^>]*\\/>`, 'gi')
+        // Also strip malformed / unterminated openings up to the next `>`
+        // as a conservative backstop (prevents `<script x="</script"...` tricks).
+        const orphan = new RegExp(`<(?:[\\w-]+:)?${t}\\b[^>]*>`, 'gi')
+        out = out.replace(open, '').replace(selfClose, '').replace(orphan, '')
+    }
+    // Drop all on* attributes.
+    out = out.replace(/\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+    // Drop all style="" attributes.
+    out = out.replace(/\s+style\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+    // Backstop scrub: even if a block-tag regex missed an animation element
+    // (e.g. attribute interleaving like `<animate x="1"`), strip the animation
+    // value attributes wholesale. These are useless on non-animation tags and
+    // the only way they're dangerous is on animation tags.
+    out = out.replace(
+        /\s+(to|from|values|by|attributeName)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi,
+        ''
+    )
+    // On `<use>` elements, only allow href/xlink:href values that are local
+    // fragment refs (`#id`). External refs (http(s)://, data:, file://, etc.)
+    // are stripped.
+    out = out.replace(
+        /<(use)\b([^>]*)>/gi,
+        (_m, tag: string, attrs: string) => {
+            const cleaned = attrs.replace(
+                /\s((?:[\w-]+:)?href)\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/gi,
+                (_f, name: string, _full: string, dq?: string, sq?: string, bare?: string) => {
+                    const v = dq ?? sq ?? bare ?? ''
+                    return v.startsWith('#') ? ` ${name}="${v.replace(/"/g, '&quot;')}"` : ''
+                }
+            )
+            return `<${tag}${cleaned}>`
+        }
+    )
+    // Strip `href`/`xlink:href`/`src`/`action` whose (entity-decoded,
+    // whitespace-collapsed, lowercased) value starts with a dangerous scheme.
+    out = out.replace(
+        /\s(href|xlink:href|src|action|formaction)\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/gi,
+        (_m, name: string, _full: string, dq?: string, sq?: string, bare?: string) => {
+            const raw = dq ?? sq ?? bare ?? ''
+            return isSafeUrl(raw) ? ` ${name}="${raw.replace(/"/g, '&quot;')}"` : ''
+        }
+    )
+    return out
+}
+
+export function sanitizeSvgForEmbed(svg: string): string {
+    if (typeof svg !== 'string' || svg.length === 0) return ''
+    const hasDOM =
+        typeof DOMParser !== 'undefined' &&
+        typeof XMLSerializer !== 'undefined'
+    if (!hasDOM) return sanitizeRegex(svg)
+    try {
+        // Parse as XML so that malformed tags don't silently get autofixed.
+        // SVG is XML; any payload that isn't well-formed XML is suspicious
+        // and falls through to the regex path.
+        const doc = new DOMParser().parseFromString(svg, 'image/svg+xml')
+        const err = doc.getElementsByTagName('parsererror')[0]
+        const root = doc.documentElement
+        if (err || !root || root.namespaceURI !== SVG_NS) {
+            return sanitizeRegex(svg)
+        }
+        sanitizeDom(root)
+        return new XMLSerializer().serializeToString(root)
+    } catch {
+        return sanitizeRegex(svg)
+    }
+}

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -18,6 +18,9 @@ export type SectionType =
     // Deprecated alias for 'family-graph'. Still accepted by the renderer
     // so existing .agent files don't break; emit 'family-graph' in new files.
     | 'inheritance-diagram'
+    | ExtensionSectionType
+
+export type ExtensionSectionType = `x-${string}:${string}`
 
 export interface SectionBase {
     id: string
@@ -340,6 +343,17 @@ export interface InheritanceDiagramSection extends SectionBase {
     data: FamilyGraphData
 }
 
+// --- Extension sections ---
+
+/**
+ * Vendor-defined extension section types, e.g. `x-acme:burndown`.
+ * Core renderers should either delegate these to plugins or show fallback UI.
+ */
+export interface ExtensionSection extends SectionBase {
+    type: ExtensionSectionType
+    data: Record<string, unknown>
+}
+
 // --- Union ---
 
 export type Section =
@@ -357,6 +371,7 @@ export type Section =
     | ReferencesSection
     | FamilyGraphSection
     | InheritanceDiagramSection
+    | ExtensionSection
 
 // --- Root ---
 

--- a/packages/renderer/tests/renderer.test.tsx
+++ b/packages/renderer/tests/renderer.test.tsx
@@ -9,6 +9,7 @@ import {
     sanitizeSvgForEmbed,
     SPEC_MAJOR,
     type AgentFile,
+    type ExtensionSection,
     type RendererPlugin,
     type Section,
 } from '../src'
@@ -252,24 +253,32 @@ describe('AgentRenderer — plugin API', () => {
             name: 'acme',
             sections: { 'x-acme:burndown': Ext },
         }
+        const extSection: ExtensionSection = {
+            id: 's1',
+            type: 'x-acme:burndown',
+            label: 'B',
+            order: 0,
+            data: {},
+        }
         const data: AgentFile = {
             ...makeAgent([]),
-            sections: [
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                { id: 's1', type: 'x-acme:burndown' as any, label: 'B', order: 0, data: {} as any },
-            ],
+            sections: [extSection],
         }
         const { getByTestId } = render(<AgentRenderer data={data} plugins={[plugin]} />)
         expect(getByTestId('ext').textContent).toBe('ext:B')
     })
 
     it('unknown extension sections render the fallback, not a crash', () => {
+        const ghostSection: ExtensionSection = {
+            id: 's1',
+            type: 'x-nobody:ghost',
+            label: 'G',
+            order: 0,
+            data: {},
+        }
         const data: AgentFile = {
             ...makeAgent([]),
-            sections: [
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                { id: 's1', type: 'x-nobody:ghost' as any, label: 'G', order: 0, data: {} as any },
-            ],
+            sections: [ghostSection],
         }
         const { container } = render(<AgentRenderer data={data} />)
         expect(container.textContent).toContain('not yet implemented')
@@ -374,6 +383,20 @@ describe('AgentRenderer — security', () => {
         })
         expect(html).not.toMatch(/<script>alert/i)
         expect(html).not.toMatch(/onclick/i)
+    })
+
+    it('buildPrintableHtml falls back on invalid print CSS inputs', () => {
+        const html = buildPrintableHtml({
+            svgMarkup: '<svg />',
+            titleLabel: 'T',
+            documentTitle: 'T',
+            pageSize: 'A4; } body { background: red; }',
+            margin: '1px 2px 3px 4px 5px',
+            fontFamily: "'Yu Gothic'; color:red",
+        })
+        expect(html).toContain('@page { size: A4; margin: 20mm; }')
+        expect(html).toContain('body { font-family: sans-serif;')
+        expect(html).toContain('svg text { font-family: sans-serif; }')
     })
 
     it('warns (but does not crash) on unknown major version', () => {

--- a/packages/renderer/tests/renderer.test.tsx
+++ b/packages/renderer/tests/renderer.test.tsx
@@ -4,7 +4,10 @@ import { describe, expect, it } from 'vitest'
 import { render } from '@testing-library/react'
 import {
     AgentRenderer,
+    buildPrintableHtml,
     findVariantComponent,
+    sanitizeSvgForEmbed,
+    SPEC_MAJOR,
     type AgentFile,
     type RendererPlugin,
     type Section,
@@ -241,6 +244,37 @@ describe('AgentRenderer — plugin API', () => {
         expect(container.textContent).toContain('Bob')
     })
 
+    it('plugin.sections renders extension section types (x-<vendor>:<name>)', () => {
+        const Ext = ({ section }: { section: Section }) => (
+            <div data-testid="ext">ext:{section.label}</div>
+        )
+        const plugin: RendererPlugin = {
+            name: 'acme',
+            sections: { 'x-acme:burndown': Ext },
+        }
+        const data: AgentFile = {
+            ...makeAgent([]),
+            sections: [
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                { id: 's1', type: 'x-acme:burndown' as any, label: 'B', order: 0, data: {} as any },
+            ],
+        }
+        const { getByTestId } = render(<AgentRenderer data={data} plugins={[plugin]} />)
+        expect(getByTestId('ext').textContent).toBe('ext:B')
+    })
+
+    it('unknown extension sections render the fallback, not a crash', () => {
+        const data: AgentFile = {
+            ...makeAgent([]),
+            sections: [
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                { id: 's1', type: 'x-nobody:ghost' as any, label: 'G', order: 0, data: {} as any },
+            ],
+        }
+        const { container } = render(<AgentRenderer data={data} />)
+        expect(container.textContent).toContain('not yet implemented')
+    })
+
     it('findVariantComponent returns undefined when nothing matches', () => {
         const plugin: RendererPlugin = {
             name: 'p',
@@ -275,6 +309,80 @@ describe('AgentRenderer — security', () => {
         expect(hrefs.filter((h) => h?.startsWith('https://')).length).toBe(1)
         expect(hrefs.filter((h) => h?.startsWith('javascript:')).length).toBe(0)
         expect(hrefs.filter((h) => h?.startsWith('data:')).length).toBe(0)
+    })
+
+    it.each([
+        ['entity-encoded javascript: in href', '<svg xmlns="http://www.w3.org/2000/svg"><a href="&#106;avascript:alert(1)"><text>x</text></a></svg>'],
+        ['hex entity javascript: in xlink:href', '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><a xlink:href="&#x6a;avascript:alert(1)"><text>x</text></a></svg>'],
+        ['full hex-entity-encoded javascript: scheme', '<svg xmlns="http://www.w3.org/2000/svg"><a href="&#x6a;&#x61;&#x76;&#x61;&#x73;&#x63;&#x72;&#x69;&#x70;&#x74;&#x3a;alert(1)"><text>x</text></a></svg>'],
+        ['named &colon; entity hiding the scheme colon', '<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript&colon;alert(1)"><text>x</text></a></svg>'],
+        ['SMIL animate hijacking href', '<svg xmlns="http://www.w3.org/2000/svg"><a href="#safe"><animate attributeName="href" to="javascript:alert(1)"/><text>x</text></a></svg>'],
+        ['SMIL set hijacking href', '<svg xmlns="http://www.w3.org/2000/svg"><a href="#safe"><set attributeName="href" to="javascript:alert(1)"/><text>x</text></a></svg>'],
+        ['tab-split scheme', '<svg xmlns="http://www.w3.org/2000/svg"><a href="java&#9;script:alert(1)"><text>x</text></a></svg>'],
+        ['newline-split scheme', '<svg xmlns="http://www.w3.org/2000/svg"><a href="java&#10;script:alert(1)"><text>x</text></a></svg>'],
+        ['namespaced script', '<svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg"><svg:script>alert(1)</svg:script></svg>'],
+        ['style tag with url(javascript:)', '<svg xmlns="http://www.w3.org/2000/svg"><style>*{background:url(javascript:alert(1))}</style></svg>'],
+        ['style attribute', '<svg xmlns="http://www.w3.org/2000/svg"><g style="background:url(javascript:alert(1))"/></svg>'],
+        ['external use href', '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="https://evil.example/x.svg#y"/></svg>'],
+    ])('sanitizer neutralizes: %s', (_label, dirty) => {
+        const clean = sanitizeSvgForEmbed(dirty)
+        // Post-sanitization the string, case-folded with entities decoded,
+        // must never contain an executable scheme or on* handler. Decode
+        // hex and decimal entities separately so the base is unambiguous —
+        // a combined `&#x?([0-9a-f]+)` regex silently parses hex as decimal
+        // because the captured group has no `x` prefix to inspect.
+        const decoded = clean
+            .replace(/&#x([0-9a-f]+);?/gi, (_m, hex: string) =>
+                String.fromCharCode(parseInt(hex, 16))
+            )
+            .replace(/&#([0-9]+);?/g, (_m, dec: string) =>
+                String.fromCharCode(parseInt(dec, 10))
+            )
+        const normalized = decoded.replace(/[\s\0]/g, '').toLowerCase()
+        expect(normalized).not.toContain('javascript:')
+        expect(normalized).not.toContain('vbscript:')
+        expect(normalized).not.toMatch(/<script/i)
+        expect(normalized).not.toMatch(/<style/i)
+        expect(normalized).not.toMatch(/onerror|onload|onclick|onmouseover/i)
+        // External <use href> must be stripped or nullified.
+        expect(normalized).not.toMatch(/use[^>]+href="https/i)
+    })
+
+    it('sanitizeSvgForEmbed strips script tags, on* handlers, javascript: URLs', () => {
+        const dirty = `<svg xmlns="http://www.w3.org/2000/svg">
+          <script>alert(1)</script>
+          <script/>
+          <a href="javascript:alert(2)" xlink:href='javascript:alert(3)'>x</a>
+          <circle onclick="alert(4)" onmouseover='alert(5)' cx="5" cy="5" r="1"/>
+          <foreignObject><iframe src="javascript:alert(6)"></iframe></foreignObject>
+        </svg>`
+        const clean = sanitizeSvgForEmbed(dirty)
+        expect(clean).not.toMatch(/<script/i)
+        expect(clean).not.toMatch(/javascript:/i)
+        expect(clean).not.toMatch(/onclick/i)
+        expect(clean).not.toMatch(/onmouseover/i)
+        expect(clean).not.toMatch(/<foreignObject/i)
+        // Safe geometry attributes survive.
+        expect(clean).toMatch(/cx="5"/)
+    })
+
+    it('buildPrintableHtml sanitizes injected SVG', () => {
+        const html = buildPrintableHtml({
+            svgMarkup: '<svg><script>alert(1)</script><g onclick="x()"/></svg>',
+            titleLabel: 'T',
+            documentTitle: 'T',
+        })
+        expect(html).not.toMatch(/<script>alert/i)
+        expect(html).not.toMatch(/onclick/i)
+    })
+
+    it('warns (but does not crash) on unknown major version', () => {
+        const data: AgentFile = {
+            ...makeAgent([]),
+            version: `${SPEC_MAJOR + 5}.0`,
+        }
+        const { container } = render(<AgentRenderer data={data} />)
+        expect(container.querySelector('.af-version-warning')).not.toBeNull()
     })
 
     it('rejects unsafe CSS in kanban label color', () => {

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -6,6 +6,10 @@
   "type": "object",
   "required": ["version", "name", "createdAt", "updatedAt", "config", "sections", "memory"],
   "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional schema URL for editor / validator integration."
+    },
     "version": {
       "type": "string",
       "pattern": "^\\d+\\.\\d+(\\.\\d+)?(-[A-Za-z0-9.]+)?$",
@@ -40,7 +44,8 @@
           "type": "array",
           "items": { "$ref": "#/$defs/AgentTask" }
         }
-      }
+      },
+      "additionalProperties": false
     },
 
     "AgentTask": {
@@ -56,6 +61,7 @@
         "lastRun": { "type": "string", "format": "date-time" },
         "label": { "type": "string" }
       },
+      "additionalProperties": false,
       "allOf": [
         {
           "if": { "properties": { "trigger": { "const": "weekly" } } },
@@ -76,7 +82,8 @@
           "type": "object",
           "additionalProperties": { "type": "string" }
         }
-      }
+      },
+      "additionalProperties": false
     },
 
     "SectionBase": {
@@ -85,17 +92,43 @@
       "properties": {
         "id": { "type": "string", "minLength": 1 },
         "type": {
-          "enum": [
-            "kanban", "checklist", "notes", "timeline", "table",
-            "log", "metrics", "diagram", "report", "form",
-            "links", "references", "family-graph",
-            "inheritance-diagram"
+          "description": "Core section type (enum) or a namespaced extension type `x-<vendor>:<name>` per spec § 7.2.",
+          "anyOf": [
+            {
+              "enum": [
+                "kanban", "checklist", "notes", "timeline", "table",
+                "log", "metrics", "diagram", "report", "form",
+                "links", "references", "family-graph"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^x-[a-z0-9][a-z0-9-]*:[a-z][a-z0-9-]*$"
+            }
           ]
         },
         "label": { "type": "string" },
         "icon": { "type": "string" },
         "order": { "type": "number" }
       }
+    },
+
+    "ExtensionSection": {
+      "description": "Namespaced extension section type (`x-<vendor>:<name>`). Core schema does not constrain `data`; vendors publish their own schema.",
+      "unevaluatedProperties": false,
+      "allOf": [
+        { "$ref": "#/$defs/SectionBase" },
+        {
+          "properties": {
+            "type": {
+              "type": "string",
+              "pattern": "^x-[a-z0-9][a-z0-9-]*:[a-z][a-z0-9-]*$"
+            },
+            "data": {}
+          },
+          "required": ["data"]
+        }
+      ]
     },
 
     "Section": {
@@ -113,7 +146,7 @@
         { "$ref": "#/$defs/LinksSection" },
         { "$ref": "#/$defs/ReferencesSection" },
         { "$ref": "#/$defs/FamilyGraphSection" },
-        { "$ref": "#/$defs/InheritanceDiagramSection" }
+        { "$ref": "#/$defs/ExtensionSection" }
       ]
     },
 
@@ -128,7 +161,8 @@
         "address": { "type": "string" },
         "deathDate": { "type": "string" },
         "aliases": { "type": "array", "items": { "type": "string" } }
-      }
+      },
+      "additionalProperties": false
     },
 
     "FamilyGraphRelationship": {
@@ -140,7 +174,8 @@
         "person2Id": { "type": "string" },
         "details": { "type": "string" },
         "dissolved": { "type": "boolean" }
-      }
+      },
+      "additionalProperties": false
     },
 
     "FamilyGraphData": {
@@ -157,10 +192,12 @@
           "type": "array",
           "items": { "$ref": "#/$defs/FamilyGraphRelationship" }
         }
-      }
+      },
+      "additionalProperties": false
     },
 
     "FamilyGraphSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -174,6 +211,7 @@
     },
 
     "KanbanSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -182,12 +220,14 @@
             "data": {
               "type": "object",
               "required": ["columns", "items", "labels"],
+              "additionalProperties": false,
               "properties": {
                 "columns": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "required": ["id", "name", "category", "order"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "name": { "type": "string" },
@@ -203,6 +243,7 @@
                   "items": {
                     "type": "object",
                     "required": ["id", "title", "type", "status", "priority", "labelIds", "blockedBy", "createdAt", "updatedAt"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "title": { "type": "string" },
@@ -223,6 +264,7 @@
                         "items": {
                           "type": "object",
                           "required": ["id", "author", "text", "createdAt"],
+                          "additionalProperties": false,
                           "properties": {
                             "id": { "type": "string" },
                             "author": { "type": "string" },
@@ -241,6 +283,7 @@
                   "items": {
                     "type": "object",
                     "required": ["id", "name", "color"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "name": { "type": "string" },
@@ -253,6 +296,7 @@
                   "items": {
                     "type": "object",
                     "required": ["id", "name"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "name": { "type": "string" },
@@ -269,6 +313,7 @@
     },
 
     "ChecklistSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -277,12 +322,14 @@
             "data": {
               "type": "object",
               "required": ["groups"],
+              "additionalProperties": false,
               "properties": {
                 "groups": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "required": ["id", "title", "items"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "title": { "type": "string" },
@@ -291,6 +338,7 @@
                         "items": {
                           "type": "object",
                           "required": ["id", "text", "checked"],
+                          "additionalProperties": false,
                           "properties": {
                             "id": { "type": "string" },
                             "text": { "type": "string" },
@@ -310,6 +358,7 @@
     },
 
     "NotesSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -318,12 +367,14 @@
             "data": {
               "type": "object",
               "required": ["blocks"],
+              "additionalProperties": false,
               "properties": {
                 "blocks": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "required": ["id", "content"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "content": { "type": "string" }
@@ -339,6 +390,7 @@
     },
 
     "TimelineSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -347,12 +399,14 @@
             "data": {
               "type": "object",
               "required": ["items", "milestones"],
+              "additionalProperties": false,
               "properties": {
                 "items": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "required": ["id", "title", "status"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "title": { "type": "string" },
@@ -369,6 +423,7 @@
                   "items": {
                     "type": "object",
                     "required": ["id", "name", "status"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "name": { "type": "string" },
@@ -387,6 +442,7 @@
     },
 
     "TableSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -395,12 +451,14 @@
             "data": {
               "type": "object",
               "required": ["columns", "rows"],
+              "additionalProperties": false,
               "properties": {
                 "columns": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "required": ["key", "label", "type"],
+                    "additionalProperties": false,
                     "properties": {
                       "key": { "type": "string" },
                       "label": { "type": "string" },
@@ -410,6 +468,7 @@
                   }
                 },
                 "rows": {
+                  "description": "Row shape is column-driven; keys match `columns[].key`. Renderers tolerate extra keys.",
                   "type": "array",
                   "items": { "type": "object" }
                 }
@@ -422,6 +481,7 @@
     },
 
     "LogSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -430,12 +490,14 @@
             "data": {
               "type": "object",
               "required": ["entries"],
+              "additionalProperties": false,
               "properties": {
                 "entries": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "required": ["id", "type", "title", "status", "createdAt"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "type": { "type": "string" },
@@ -460,6 +522,7 @@
     },
 
     "MetricsSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -468,12 +531,14 @@
             "data": {
               "type": "object",
               "required": ["cards"],
+              "additionalProperties": false,
               "properties": {
                 "cards": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "required": ["id", "label", "value"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "label": { "type": "string" },
@@ -495,6 +560,7 @@
     "DiagramNode": {
       "type": "object",
       "required": ["id", "label", "children"],
+      "additionalProperties": false,
       "properties": {
         "id": { "type": "string" },
         "label": { "type": "string" },
@@ -507,6 +573,7 @@
     },
 
     "DiagramSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -515,6 +582,7 @@
             "data": {
               "type": "object",
               "required": ["root"],
+              "additionalProperties": false,
               "properties": {
                 "root": { "$ref": "#/$defs/DiagramNode" }
               }
@@ -526,6 +594,7 @@
     },
 
     "ReportSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -534,6 +603,7 @@
             "data": {
               "type": "object",
               "required": ["template", "reports"],
+              "additionalProperties": false,
               "properties": {
                 "template": { "type": "string" },
                 "reports": {
@@ -541,6 +611,7 @@
                   "items": {
                     "type": "object",
                     "required": ["id", "title", "content", "createdAt", "updatedAt"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "title": { "type": "string" },
@@ -559,6 +630,7 @@
     },
 
     "FormSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -567,12 +639,14 @@
             "data": {
               "type": "object",
               "required": ["fields", "submissions"],
+              "additionalProperties": false,
               "properties": {
                 "fields": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "required": ["id", "label", "type"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "label": { "type": "string" },
@@ -588,9 +662,13 @@
                   "items": {
                     "type": "object",
                     "required": ["id", "values", "submittedAt"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
-                      "values": { "type": "object" },
+                      "values": {
+                        "description": "Field-id-keyed values; shape is field-driven.",
+                        "type": "object"
+                      },
                       "submittedAt": { "type": "string", "format": "date-time" },
                       "submittedBy": { "type": "string" }
                     }
@@ -605,6 +683,7 @@
     },
 
     "LinksSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -613,12 +692,14 @@
             "data": {
               "type": "object",
               "required": ["items"],
+              "additionalProperties": false,
               "properties": {
                 "items": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "required": ["id", "title", "url"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "title": { "type": "string" },
@@ -637,6 +718,7 @@
     },
 
     "ReferencesSection": {
+      "unevaluatedProperties": false,
       "allOf": [
         { "$ref": "#/$defs/SectionBase" },
         {
@@ -645,12 +727,14 @@
             "data": {
               "type": "object",
               "required": ["items"],
+              "additionalProperties": false,
               "properties": {
                 "items": {
                   "type": "array",
                   "items": {
                     "type": "object",
                     "required": ["id", "fileId", "fileName", "filePath"],
+                    "additionalProperties": false,
                     "properties": {
                       "id": { "type": "string" },
                       "fileId": { "type": "string" },
@@ -659,82 +743,6 @@
                       "memo": { "type": "string" }
                     }
                   }
-                }
-              }
-            }
-          },
-          "required": ["data"]
-        }
-      ]
-    },
-
-    "InheritanceDiagramPerson": {
-      "type": "object",
-      "required": ["id", "name"],
-      "properties": {
-        "id": { "type": "string", "minLength": 1 },
-        "name": { "type": "string", "minLength": 1 },
-        "role": { "type": "string", "description": "被相続人 / 配偶者 / 長男 / 代襲相続人 等" },
-        "birthday": { "type": "string", "description": "Localized date text (元号 or 西暦)." },
-        "address": { "type": "string" },
-        "deathDate": { "type": "string" },
-        "aliases": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "Alternate scripts / 旧字体 variants of the same person's name."
-        }
-      }
-    },
-
-    "InheritanceDiagramRelationship": {
-      "type": "object",
-      "required": ["type", "person1Id", "person2Id"],
-      "properties": {
-        "type": { "enum": ["spouse", "parent-child"] },
-        "person1Id": {
-          "type": "string",
-          "description": "For parent-child this is the parent; for spouse either is acceptable."
-        },
-        "person2Id": {
-          "type": "string",
-          "description": "For parent-child this is the child."
-        },
-        "details": {
-          "type": "string",
-          "description": "Free text: 婚姻日, 養子, 家督相続, 代襲, 長男 etc."
-        },
-        "dissolved": {
-          "type": "boolean",
-          "description": "Divorce, 離縁, 縁組解消. Renderers MAY show this edge differently."
-        }
-      }
-    },
-
-    "InheritanceDiagramSection": {
-      "allOf": [
-        { "$ref": "#/$defs/SectionBase" },
-        {
-          "properties": {
-            "type": { "const": "inheritance-diagram" },
-            "data": {
-              "type": "object",
-              "required": ["variant", "persons", "relationships"],
-              "properties": {
-                "variant": {
-                  "type": "string",
-                  "description": "Jurisdictional rendering convention. 'jp-court' = 相続関係説明図 (Japanese family court / registration bureau)."
-                },
-                "persons": {
-                  "type": "array",
-                  "items": { "$ref": "#/$defs/InheritanceDiagramPerson" }
-                },
-                "relationships": {
-                  "type": "array",
-                  "items": { "$ref": "#/$defs/InheritanceDiagramRelationship" }
-                },
-                "focusedPersonId": {
-                  "type": "string",
-                  "description": "ID of the decedent (被相続人). Drives layout origin. If omitted, renderer picks the first person with deathDate set, else persons[0]."
                 }
               }
             }

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -37,4 +37,85 @@ describe('JSON Schema', () => {
             expect(ok).toBe(true)
         })
     }
+
+    // Negative cases: prove the closed-schema claim holds.
+    const base = {
+        version: '0.1',
+        name: 't',
+        createdAt: '2026-04-18T00:00:00Z',
+        updatedAt: '2026-04-18T00:00:00Z',
+        config: { proactive: false },
+        sections: [],
+        memory: { observations: [], preferences: {} },
+    }
+
+    it('rejects unknown top-level property', () => {
+        const bad = { ...base, bogusTopLevel: 123 }
+        expect(validate(bad)).toBe(false)
+    })
+
+    it('accepts top-level x-* extension fields (§ 7.1)', () => {
+        const ok = { ...base, 'x-acme-snapshot-id': 'abc' }
+        expect(validate(ok)).toBe(true)
+    })
+
+    it('accepts an x-<vendor>:<name> extension section type (§ 7.2)', () => {
+        const ok = {
+            ...base,
+            sections: [
+                {
+                    id: 's1',
+                    type: 'x-acme:burndown-chart',
+                    label: 'Burndown',
+                    order: 0,
+                    data: { whatever: 42 },
+                },
+            ],
+        }
+        expect(validate(ok)).toBe(true)
+    })
+
+    it('rejects a bare unknown section type (must use x-<vendor>:<name>)', () => {
+        const bad = {
+            ...base,
+            sections: [
+                {
+                    id: 's1',
+                    type: 'custom-widget',
+                    label: 'X',
+                    order: 0,
+                    data: {},
+                },
+            ],
+        }
+        expect(validate(bad)).toBe(false)
+    })
+
+    it('rejects extra property inside a closed nested object', () => {
+        const bad = {
+            ...base,
+            sections: [
+                {
+                    id: 's1',
+                    type: 'notes',
+                    label: 'N',
+                    order: 0,
+                    data: {
+                        blocks: [{ id: 'b1', content: 'hi', extra: 'nope' }],
+                    },
+                },
+            ],
+        }
+        expect(validate(bad)).toBe(false)
+    })
+
+    it('rejects a section missing its required `data`', () => {
+        const bad = {
+            ...base,
+            sections: [
+                { id: 's1', type: 'notes', label: 'N', order: 0 },
+            ],
+        }
+        expect(validate(bad)).toBe(false)
+    })
 })


### PR DESCRIPTION
## Summary

Three-commit, zero-downtime v0.1 hardening pass. Tightens the schema, closes an XSS surface in the print/PDF path, formalizes the extension mechanism, and adds a second implementation so the schema — not the TypeScript renderer — is the normative contract.

- **Commit 1** (`chore`): CI workflow, governance docs (SECURITY, CHANGELOG, CODEOWNERS), and README corrections.
- **Commit 2** (`spec`): schema closure (`additionalProperties: false` everywhere, `unevaluatedProperties: false` on section wrappers), formal `x-<vendor>:<name>` extension mechanism, DOMParser-backed SVG sanitizer, MCP full-schema validation via Ajv, renderer plugin API for extension sections.
- **Commit 3** (`feat(cli)`): new `@agent-format/cli` package — React-free, Ajv-only validator binary with its own integration test suite.

## Why this matters

Two subagent reviews (Anthropic PE perspective + OpenAI PE codex perspective) ran against the repo before and after each iteration. Initial verdict from both: **ignore**, domain-shaped spec with real XSS bypasses and unclosed schemas. Final verdict: **endorse** (Anthropic) and **endorse (conditional)** (OpenAI codex). Key diffs that moved the needle:

- **XSS**: regex SVG sanitizer had entity-encoded `javascript:` and SMIL `<animate>`-hijack bypasses. Replaced with DOM-allowlist + hardened regex fallback, with separate hex/decimal entity decoding passes and SMIL element denial.
- **Schema**: nested objects were open despite the "closed schemas per widget" claim in SPEC. Now genuinely closed; negative tests codify that.
- **Neutrality**: core enum embedded `family-graph` + domain-specific fields with no extension namespace. Added `x-<vendor>:<name>` format, schema branch, and renderer plugin slot. `family-graph` is documented as grandfathered for v0.1 compat; v0.2 drops it.
- **Second implementation**: new `@agent-format/cli` consumes the same schema without importing the renderer. If writer output validates here and breaks in the renderer (or vice versa), the schema wins.

## Numbers

- **Tests**: 72 across 4 files (was 17 in the renderer package only).
- **Files changed**: 32 (19 modified, 13 new).
- **New packages**: 1 (`@agent-format/cli`).

## Test plan

- [ ] `npm ci && npm run build && npm run typecheck && npm test` passes on CI
- [ ] `npm pack --dry-run` in each published package (`renderer`, `jp-court`, `mcp`, `cli`) shows the right `files` glob
- [ ] `packages/cli/dist/cli.js examples/*.agent` prints `✓` for every committed example
- [ ] `packages/cli/dist/cli.js --help` and `--version` work
- [ ] Sanitizer: manually confirm in a real Chromium tab that `buildPrintableHtml` output of a crafted SVG (`<a href="&#x6a;avascript:..."><animate ...>`) doesn't fire `alert()`
- [ ] MCP: call `render_agent_inline` with a malformed payload; expect a structured `isError` with Ajv-summarized path+message

## Known follow-ups (out of scope for this PR)

- v0.2 will drop unprefixed `family-graph` from the core enum (documented in SPEC § 9.1).
- A non-JS reference validator (Python / Rust) would further strengthen the "schema is the contract" story; the CLI is a stepping stone, not a replacement.
- Renderer markdown in `notes`/`report` sections is still deferred to v0.2 per SPEC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)