### PR TITLE
chore(repo): professional repo hygiene

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Something that renders, validates, or round-trips incorrectly.
+title: "bug: "
+labels: [bug, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. **Do not** report security
+        vulnerabilities here — use the private advisory link on the issue picker.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which package / area?
+      options:
+        - "@agent-format/renderer"
+        - "@agent-format/viewer"
+        - "@agent-format/mcp"
+        - "@agent-format/cli"
+        - "@agent-format/jp-court"
+        - Spec / schema
+        - Docs / examples
+        - Other
+      default: 0
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      description: Run `npm ls <package>` or check `package.json`.
+      placeholder: "0.1.5"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce
+      description: Minimal steps or a code snippet. A small `.agent` fixture is ideal.
+      placeholder: |
+        1. Run `agent-format path/to/file.agent`
+        2. Observed error: ...
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Node version, OS, and browser if relevant.
+      placeholder: "Node 20.11, macOS 14.4, Chrome 126"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or stack trace
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/knorq-ai/agent-format/security/advisories/new
+    about: Please disclose privately via a security advisory (see SECURITY.md).
+  - name: Spec / schema discussion
+    url: https://github.com/knorq-ai/agent-format/discussions
+    about: Open-ended design or roadmap questions about .agent v0.x.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: A new section type, renderer capability, tooling, or spec addition.
+title: "feat: "
+labels: [enhancement, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If your idea is a new **section type**, please check § 7.2 of
+        [SPEC.md](../SPEC.md) first — most new section types belong in a
+        plugin registered as `x-<vendor>:<name>` rather than the core enum.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Tell us about the user pain this would address.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Sketch API / schema / rendering behavior. Rough is fine.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you think about? Why is the proposal better?
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Core spec / schema change
+        - New built-in section type
+        - New extension section (`x-<vendor>:<name>`)
+        - Renderer / viewer enhancement
+        - MCP server enhancement
+        - CLI enhancement
+        - Docs / examples
+      default: 2
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!-- Thanks for contributing! Please keep the title short (<70 chars); detail goes in this body. -->
+
+## Summary
+
+<!-- What does this PR change and why? 1–3 bullets. -->
+
+## Type of change
+
+- [ ] Spec / schema change (touches `SPEC.md` or `schemas/agent.schema.json`)
+- [ ] Renderer / viewer behavior
+- [ ] MCP server behavior
+- [ ] CLI validator behavior
+- [ ] Docs / examples only
+- [ ] Build / CI / tooling
+
+## Breaking change?
+
+- [ ] No
+- [ ] Yes — CHANGELOG.md updated and migration notes below
+
+<!-- If yes, describe who breaks and how they migrate. -->
+
+## Test plan
+
+<!-- What did you run locally? Check off what applies. -->
+
+- [ ] `npm test` (all 74+ vitest cases green)
+- [ ] `npm run typecheck`
+- [ ] `npm run build`
+- [ ] Manually exercised the affected path (describe below)
+- [ ] Adversarial XSS / schema payload attempted against `sanitize.ts` or `agent.schema.json`
+
+## Security considerations
+
+<!-- If this PR touches renderer HTML/SVG embedding, MCP path handling, URL
+attrs, or the sanitizer: what's the new trust boundary? -->
+
+- [ ] No security-relevant surface changed
+- [ ] `SECURITY.md` threat-model table updated
+
+## Related issues / PRs
+
+<!-- Link with `Fixes #nnn` / `Refs #nnn` -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+updates:
+  # npm — run weekly so lockfile churn is predictable and reviewable.
+  # Grouped by ecosystem to collapse related bumps into a single PR.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      typescript:
+        patterns:
+          - typescript
+          - "@types/*"
+          - "tsup"
+          - "tsx"
+      react:
+        patterns:
+          - react
+          - react-dom
+          - "@testing-library/*"
+      test:
+        patterns:
+          - vitest
+          - "@vitest/*"
+          - happy-dom
+      schema:
+        patterns:
+          - ajv
+          - ajv-formats
+          - ajv-*
+      mcp:
+        patterns:
+          - "@modelcontextprotocol/*"
+    ignore:
+      # Pin the MCP Apps SDK major until we validate the render pipeline.
+      - dependency-name: "@modelcontextprotocol/ext-apps"
+        update-types: [version-update:semver-major]
+
+  # Keep Actions SHA-pins fresh — security patches land via Dependabot.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: ci
+      include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,40 @@ on:
   pull_request:
     branches: [main]
 
+# Default to read-only. No job in this workflow needs to write to the repo,
+# open PRs, publish packages, or post comments, so lock the token down.
+permissions:
+  contents: read
+
+# If a branch receives rapid pushes (rebases, force-pushes), cancel the
+# prior run instead of piling up queue pressure.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
+    name: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # SHA-pinned: tags are mutable, commit SHAs are not. Dependabot keeps
+      # these fresh via `package-ecosystem: github-actions` in dependabot.yml.
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.3
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.1
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
-      - run: npm run build
-      - run: npm run typecheck
-      - run: npm test
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Test
+        run: npm test
       - name: npm pack dry-run (catches broken files globs)
         run: |
           for pkg in packages/renderer packages/jp-court packages/mcp packages/cli; do


### PR DESCRIPTION
## Summary

Paired file + API changes that bring the repo up to a baseline you'd expect from a published OSS spec.

**Files in this PR**
- `.github/dependabot.yml` — weekly npm + Actions updates, grouped by ecosystem so lockfile churn collapses into reviewable batches.
- `.github/PULL_REQUEST_TEMPLATE.md` — scoped-type checklist including a security-considerations section for sanitizer / path / URL surface changes.
- `.github/ISSUE_TEMPLATE/{bug_report.yml,feature_request.yml,config.yml}` — structured intake with package picker; blank issues off; security reports routed to the private advisory form.
- `.github/workflows/ci.yml`:
  - SHA-pin `actions/checkout` and `actions/setup-node` (Dependabot will keep them fresh via `github-actions` ecosystem).
  - `permissions: contents: read` at workflow scope.
  - `concurrency` group so force-pushes cancel superseded runs.
  - `timeout-minutes: 10`, explicit step names, stable job name `verify` that branch-protection rules can target.

**Already applied via API (out of diff)**
- Merge strategy: squash-only; auto-delete merged branches.
- Secret scanning + push protection enabled.
- Dependabot security updates enabled.

## What is NOT in this PR (follow-up)

Once this lands and CI produces the `verify` check on `main`, we should add a **branch protection ruleset** on `main` requiring: `verify` status check to pass, PR before merge, block force-push, block deletion, require linear history. I left this out so it doesn't gate the PR that introduces the check name itself.

## Test plan

- [ ] CI run on this PR goes green with the new SHA-pinned setup
- [ ] Dependabot picks up `.github/dependabot.yml` (visible in the Insights → Dependency graph tab within a few minutes)
- [ ] Issue creation flow shows the new templates in the issue picker
- [ ] PR template renders on new PRs (verify on the next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)