### PR TITLE
[codex] add interactive jp-court family graph editing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Something that renders, validates, or round-trips incorrectly.
+title: "bug: "
+labels: [bug, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. **Do not** report security
+        vulnerabilities here — use the private advisory link on the issue picker.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which package / area?
+      options:
+        - "@agent-format/renderer"
+        - "@agent-format/viewer"
+        - "@agent-format/mcp"
+        - "@agent-format/cli"
+        - "@agent-format/jp-court"
+        - Spec / schema
+        - Docs / examples
+        - Other
+      default: 0
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      description: Run `npm ls <package>` or check `package.json`.
+      placeholder: "0.1.5"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce
+      description: Minimal steps or a code snippet. A small `.agent` fixture is ideal.
+      placeholder: |
+        1. Run `agent-format path/to/file.agent`
+        2. Observed error: ...
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Node version, OS, and browser if relevant.
+      placeholder: "Node 20.11, macOS 14.4, Chrome 126"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or stack trace
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/knorq-ai/agent-format/security/advisories/new
+    about: Please disclose privately via a security advisory (see SECURITY.md).
+  - name: Spec / schema discussion
+    url: https://github.com/knorq-ai/agent-format/discussions
+    about: Open-ended design or roadmap questions about .agent v0.x.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: A new section type, renderer capability, tooling, or spec addition.
+title: "feat: "
+labels: [enhancement, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If your idea is a new **section type**, please check § 7.2 of
+        [SPEC.md](../SPEC.md) first — most new section types belong in a
+        plugin registered as `x-<vendor>:<name>` rather than the core enum.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Tell us about the user pain this would address.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Sketch API / schema / rendering behavior. Rough is fine.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you think about? Why is the proposal better?
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Core spec / schema change
+        - New built-in section type
+        - New extension section (`x-<vendor>:<name>`)
+        - Renderer / viewer enhancement
+        - MCP server enhancement
+        - CLI enhancement
+        - Docs / examples
+      default: 2
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!-- Thanks for contributing! Please keep the title short (<70 chars); detail goes in this body. -->
+
+## Summary
+
+<!-- What does this PR change and why? 1–3 bullets. -->
+
+## Type of change
+
+- [ ] Spec / schema change (touches `SPEC.md` or `schemas/agent.schema.json`)
+- [ ] Renderer / viewer behavior
+- [ ] MCP server behavior
+- [ ] CLI validator behavior
+- [ ] Docs / examples only
+- [ ] Build / CI / tooling
+
+## Breaking change?
+
+- [ ] No
+- [ ] Yes — CHANGELOG.md updated and migration notes below
+
+<!-- If yes, describe who breaks and how they migrate. -->
+
+## Test plan
+
+<!-- What did you run locally? Check off what applies. -->
+
+- [ ] `npm test` (all 74+ vitest cases green)
+- [ ] `npm run typecheck`
+- [ ] `npm run build`
+- [ ] Manually exercised the affected path (describe below)
+- [ ] Adversarial XSS / schema payload attempted against `sanitize.ts` or `agent.schema.json`
+
+## Security considerations
+
+<!-- If this PR touches renderer HTML/SVG embedding, MCP path handling, URL
+attrs, or the sanitizer: what's the new trust boundary? -->
+
+- [ ] No security-relevant surface changed
+- [ ] `SECURITY.md` threat-model table updated
+
+## Related issues / PRs
+
+<!-- Link with `Fixes #nnn` / `Refs #nnn` -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+updates:
+  # npm — run weekly so lockfile churn is predictable and reviewable.
+  # Grouped by ecosystem to collapse related bumps into a single PR.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      typescript:
+        patterns:
+          - typescript
+          - "@types/*"
+          - "tsup"
+          - "tsx"
+      react:
+        patterns:
+          - react
+          - react-dom
+          - "@testing-library/*"
+      test:
+        patterns:
+          - vitest
+          - "@vitest/*"
+          - happy-dom
+      schema:
+        patterns:
+          - ajv
+          - ajv-formats
+          - ajv-*
+      mcp:
+        patterns:
+          - "@modelcontextprotocol/*"
+    ignore:
+      # Pin the MCP Apps SDK major until we validate the render pipeline.
+      - dependency-name: "@modelcontextprotocol/ext-apps"
+        update-types: [version-update:semver-major]
+
+  # Keep Actions SHA-pins fresh — security patches land via Dependabot.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: ci
+      include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,40 @@ on:
   pull_request:
     branches: [main]
 
+# Default to read-only. No job in this workflow needs to write to the repo,
+# open PRs, publish packages, or post comments, so lock the token down.
+permissions:
+  contents: read
+
+# If a branch receives rapid pushes (rebases, force-pushes), cancel the
+# prior run instead of piling up queue pressure.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
+    name: verify
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # SHA-pinned: tags are mutable, commit SHAs are not. Dependabot keeps
+      # these fresh via `package-ecosystem: github-actions` in dependabot.yml.
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.3
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.1
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
-      - run: npm run build
-      - run: npm run typecheck
-      - run: npm test
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Test
+        run: npm test
       - name: npm pack dry-run (catches broken files globs)
         run: |
           for pkg in packages/renderer packages/jp-court packages/mcp packages/cli; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release
+
+# Tag-driven npm publish with provenance.
+#
+# Tag format: "<pkg>-v<semver>"  where <pkg> is one of
+#   renderer | jp-court | mcp | cli
+# e.g. "renderer-v0.1.6", "cli-v0.2.0".
+#
+# The matching workspace package is version-checked against the tag, built,
+# and published with `npm publish --provenance`, which attaches an OIDC-
+# signed SLSA provenance statement so consumers can verify the tarball came
+# from this repo + this workflow.
+
+on:
+  push:
+    tags:
+      - 'renderer-v*'
+      - 'jp-court-v*'
+      - 'mcp-v*'
+      - 'cli-v*'
+
+# id-token:write is what lets `npm publish --provenance` mint the OIDC
+# attestation. contents:read is all we need from the checkout.
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.1
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Resolve package from tag
+        id: pkg
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          # Tag looks like "renderer-v0.1.6". Split at the last "-v".
+          tag="$GITHUB_REF_NAME"
+          name="${tag%-v*}"
+          version="${tag##*-v}"
+          case "$name" in
+            renderer|jp-court|mcp|cli) ;;
+            *) echo "Unsupported package name: $name" >&2; exit 1 ;;
+          esac
+          dir="packages/$name"
+          if [ ! -f "$dir/package.json" ]; then
+            echo "No package.json at $dir" >&2
+            exit 1
+          fi
+          pkg_version=$(node -p "require('./$dir/package.json').version")
+          if [ "$pkg_version" != "$version" ]; then
+            echo "Tag version ($version) does not match $dir/package.json ($pkg_version)" >&2
+            exit 1
+          fi
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install
+        run: npm ci
+
+      - name: Build (all workspaces — cross-package deps must be fresh)
+        run: npm run build
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Publish with provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        working-directory: ${{ steps.pkg.outputs.dir }}
+        run: npm publish --provenance --access public

--- a/README.md
+++ b/README.md
@@ -1,21 +1,39 @@
 # Agent File Format
 
-**A structured alternative to HTML for AI-generated visualizations — editable by the user, re-readable by the agent.**
+**A round-trip loop between an agent and a human, backed by a typed JSON file.**
+
+The agent writes. You edit in a rendered UI. The agent reads your edits next turn.
 
 > Status: **Draft v0.1** — not yet stable. Expect breaking changes until v1.0.
 >
-> **Note:** Not related to [`dotagent`](https://github.com/johnlindquist/dotagent) by @johnlindquist — that tool unifies IDE rule files (CLAUDE.md / `.cursorrules` / etc.). This spec defines a typed JSON artifact format for agent-rendered dashboards.
+> **Note:** Not related to [`dotagent`](https://github.com/johnlindquist/dotagent) by @johnlindquist — that tool unifies IDE rule files (CLAUDE.md / `.cursorrules` / etc.). This project defines a typed JSON artifact for agent-rendered, human-editable state.
 
-When you ask an AI to "turn this email into a kanban" or "visualize this PDF as a mindmap," today it writes hundreds of lines of HTML/CSS for something that should be a few dozen lines of data. The output is static, expensive to generate, and round-trip-lossy — drag a card and the agent can't re-read your edits.
+## The loop
 
-`.agent` is a typed JSON artifact that:
+Today, when you ask an AI to "turn this email into a kanban" or "visualize this PDF as a mindmap," it writes hundreds of lines of HTML/CSS for something that should be a few dozen lines of data. Static output. Expensive to generate. Drag a card and the agent can't re-read your edit.
 
-1. **The agent writes as data** — tens of lines of JSON instead of hundreds of lines of HTML.
-2. **Renders as a rich interactive UI** — kanban, timeline, mindmap, table, metrics, log, and more — via any conformant renderer.
-3. **The user edits directly** — drag cards, inline text, no "copy and re-prompt."
-4. **The agent re-reads next time** — changes persist; state survives across sessions.
+`.agent` closes that loop:
 
-Because the file is just JSON on disk, you can commit it to git, email it, share it between apps. The same artifact is the agent's output *and* the human's working surface.
+1. **The agent writes data.** Tens of lines of typed JSON instead of hundreds of lines of markup.
+2. **A renderer turns it into an interactive dashboard.** Kanban, timeline, mindmap, table, metrics, log, and more — drag, inline-edit, rearrange.
+3. **The file is on disk.** Commit to git, email it, share between apps.
+4. **The agent re-reads next turn.** Your edits flow back; state survives across sessions.
+
+The same artifact is the agent's output *and* the human's working surface.
+
+## One install, any MCP client
+
+The `@agent-format/mcp` server ships three things in one package:
+
+- the **renderer** that draws `.agent` inline in Claude Desktop / Cursor / VS Code Copilot / any MCP Apps client,
+- the **authoring skill** so the model knows when to emit `.agent` instead of an HTML artifact (exposed as an MCP tool, resources, and a slash-command prompt — the pre-spec "skills over MCP" pattern),
+- and the **schema validator** so malformed documents never reach the UI.
+
+```bash
+npx @agent-format/mcp
+```
+
+Add it to your client's MCP config once. No separate plugin install, no extra setup per client. See [`packages/mcp/README.md`](./packages/mcp/README.md) for per-client config.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -16,7 +16,7 @@ A conforming renderer MUST display each section using the section's type-specifi
 2. **Typed, closed schemas per widget.** Each section type has a well-defined shape. LLMs produce reliable edits because the schema is narrow.
 3. **Portable.** A user can commit an `.agent` file to git, attach it to an email, or share it between apps.
 4. **Human- and agent-editable.** The format is designed to be read and written by *both* a human through a UI and an LLM through direct JSON manipulation.
-5. **Extensible without breaking.** Unknown fields MUST be preserved by round-trippers; unknown section types MUST NOT error the reader.
+5. **Extensible without breaking.** Extension surfaces are well-defined: top-level `x-*` fields (§ 7.1) and namespaced extension section types `x-<vendor>:<name>` (§ 7.2). These MUST be preserved by round-trippers and MUST NOT error the reader. Core section `data` payloads are typed closed (§ 4) — vendors adding fields MUST use an extension section type, not inject unknown keys into a core type.
 
 ### 1.2 File metadata
 
@@ -363,7 +363,7 @@ A conforming writer MUST:
 - Produce documents that validate against [`schemas/agent.schema.json`](./schemas/agent.schema.json).
 - Set `version` to a supported spec version.
 - Set `createdAt` and `updatedAt`; update `updatedAt` on every write.
-- Preserve unknown fields when round-tripping an existing file.
+- Preserve top-level `x-*` fields (§ 7.1) and extension sections (§ 7.2) when round-tripping an existing file. Core section payloads are closed — do not round-trip unknown keys *inside* a core section; vendors needing that surface MUST use an extension section type.
 
 A conforming writer SHOULD:
 
@@ -375,13 +375,14 @@ A conforming writer SHOULD:
 A conforming reader MUST:
 
 - Render sections by `type` and display them in `order` ascending.
-- Not error on unknown section types; fall back to a minimal display (e.g. "Unknown section: X").
-- Not error on unknown optional fields.
+- Not error on unknown section types (extension types `x-<vendor>:<name>` it does not recognize); fall back to a minimal display (e.g. "Unknown section: X").
+- Not error on unknown top-level `x-*` fields.
+- Tolerate (not crash on) unknown keys inside core section payloads produced by non-conforming writers — drop or ignore them in render, not throw. This is runtime robustness, separate from schema validation.
 
 A conforming reader SHOULD:
 
 - Allow the user to edit sections directly.
-- Preserve unknown fields when saving.
+- Preserve top-level `x-*` fields and extension sections when saving.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4443,11 +4443,11 @@
     },
     "packages/mcp": {
       "name": "@agent-format/mcp",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@agent-format/jp-court": "0.1.2",
-        "@agent-format/renderer": "0.1.5",
+        "@agent-format/renderer": "0.1.6",
         "@modelcontextprotocol/ext-apps": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ajv": "^8.17.0",
@@ -4935,7 +4935,7 @@
     },
     "packages/renderer": {
       "name": "@agent-format/renderer",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^19.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4964,6 +4964,8 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
+        "ajv": "^8.17.0",
+        "ajv-formats": "^3.0.0",
         "typescript": "^5.4.0",
         "vite": "^5.4.0"
       }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,6 +11,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createRequire } from 'node:module'
+import { validateSemantics, type SemanticError } from './semantic.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const requireCjs = createRequire(import.meta.url)
@@ -35,6 +36,7 @@ interface Args {
     version: boolean
     allErrors: boolean
     quiet: boolean
+    skipSemantic: boolean
 }
 
 function parseArgs(argv: string[]): Args {
@@ -44,12 +46,14 @@ function parseArgs(argv: string[]): Args {
         version: false,
         allErrors: true,
         quiet: false,
+        skipSemantic: false,
     }
     for (const a of argv) {
         if (a === '-h' || a === '--help') out.help = true
         else if (a === '-v' || a === '--version') out.version = true
         else if (a === '--first-error-only') out.allErrors = false
         else if (a === '-q' || a === '--quiet') out.quiet = true
+        else if (a === '--skip-semantic') out.skipSemantic = true
         else if (a.startsWith('-')) {
             console.error(`Unknown flag: ${a}`)
             process.exit(2)
@@ -71,6 +75,7 @@ function usage(): string {
         '  -h, --help              Show this help and exit.',
         '  -v, --version           Print the CLI version and schema $id.',
         '  --first-error-only      Stop at the first validation error per file.',
+        '  --skip-semantic         Skip the semantic pass (ID uniqueness, refs).',
         '  -q, --quiet             Only print paths of failing files.',
     ].join('\n')
 }
@@ -92,6 +97,10 @@ function pkgVersion(): string {
 function formatError(e: AjvErrorsEntry): string {
     const path = e.instancePath || '/'
     return `  ${path}: ${e.message ?? 'invalid'}`
+}
+
+function formatSemanticError(e: SemanticError): string {
+    return `  ${e.instancePath || '/'}: ${e.message}`
 }
 
 async function main(): Promise<void> {
@@ -125,9 +134,23 @@ async function main(): Promise<void> {
             )
             continue
         }
+        // Separate read from parse so filesystem errors (EISDIR from a
+        // directory path, EACCES, ENOENT) don't get mislabeled as JSON
+        // parse failures — that misdirection sends users hunting for a
+        // syntax bug that isn't there.
+        let text: string
+        try {
+            text = fs.readFileSync(resolved, 'utf8')
+        } catch (err) {
+            fails++
+            process.stderr.write(
+                `✗ ${file}: cannot read — ${(err as Error).message}\n`
+            )
+            continue
+        }
         let data: unknown
         try {
-            data = JSON.parse(fs.readFileSync(resolved, 'utf8'))
+            data = JSON.parse(text)
         } catch (err) {
             fails++
             process.stderr.write(
@@ -135,9 +158,7 @@ async function main(): Promise<void> {
             )
             continue
         }
-        if (validate(data)) {
-            if (!args.quiet) process.stdout.write(`✓ ${file}\n`)
-        } else {
+        if (!validate(data)) {
             fails++
             process.stderr.write(`✗ ${file}\n`)
             if (!args.quiet) {
@@ -145,7 +166,20 @@ async function main(): Promise<void> {
                     process.stderr.write(formatError(e) + '\n')
                 }
             }
+            continue
         }
+        const semanticErrors = args.skipSemantic ? [] : validateSemantics(data)
+        if (semanticErrors.length > 0) {
+            fails++
+            process.stderr.write(`✗ ${file} (semantic)\n`)
+            if (!args.quiet) {
+                for (const e of semanticErrors) {
+                    process.stderr.write(formatSemanticError(e) + '\n')
+                }
+            }
+            continue
+        }
+        if (!args.quiet) process.stdout.write(`✓ ${file}\n`)
     }
     process.exit(fails === 0 ? 0 : 1)
 }

--- a/packages/cli/src/semantic.ts
+++ b/packages/cli/src/semantic.ts
@@ -1,0 +1,437 @@
+// Semantic validation — the checks the JSON Schema cannot express.
+//
+// The schema in `schemas/agent.schema.json` is structural: it enforces shape
+// and required fields. It cannot enforce that IDs are unique within a parent
+// collection, that a kanban item's `status` points at a real column, or that
+// a table cell for a `status` column has the `{ state, comment? }` object
+// shape. Those checks live here. Call `validateSemantics` after the schema
+// validation passes so reports surface one layer at a time.
+//
+// This module is pure TS with no deps so both the CLI and, in future, other
+// validators can lift it verbatim.
+
+export interface SemanticError {
+    instancePath: string
+    message: string
+}
+
+type AnyObj = Record<string, unknown>
+
+function isObj(x: unknown): x is AnyObj {
+    return typeof x === 'object' && x !== null && !Array.isArray(x)
+}
+
+// Collect duplicate IDs across an array of { id: string } objects and emit
+// one error per duplicate group (not per collision) so the CLI output stays
+// readable on large boards.
+// instancePath values emitted here follow RFC 6901 JSON Pointer — the same
+// format Ajv uses — so CLI stderr and the viewer's error list can be filtered
+// with `jq`/awk uniformly regardless of which stage raised the error.
+function checkUniqueIds(
+    items: unknown,
+    basePath: string,
+    errors: SemanticError[]
+): void {
+    if (!Array.isArray(items)) return
+    const seen = new Map<string, number[]>()
+    items.forEach((item, idx) => {
+        if (!isObj(item)) return
+        const id = item.id
+        if (typeof id !== 'string') return
+        const hits = seen.get(id)
+        if (hits) hits.push(idx)
+        else seen.set(id, [idx])
+    })
+    for (const [id, hits] of seen) {
+        if (hits.length > 1) {
+            errors.push({
+                instancePath: `${basePath}/${hits[0]}`,
+                message: `duplicate id "${id}" in ${basePath} (also at ${hits
+                    .slice(1)
+                    .map((i) => `${basePath}/${i}`)
+                    .join(', ')})`,
+            })
+        }
+    }
+}
+
+function validateKanban(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    const columns = Array.isArray(data.columns) ? data.columns : []
+    const items = Array.isArray(data.items) ? data.items : []
+    const labels = Array.isArray(data.labels) ? data.labels : []
+    const team = Array.isArray(data.team) ? data.team : []
+
+    const sec = `/sections/${secIdx}/data`
+    checkUniqueIds(columns, `${sec}/columns`, errors)
+    checkUniqueIds(items, `${sec}/items`, errors)
+    checkUniqueIds(labels, `${sec}/labels`, errors)
+    checkUniqueIds(team, `${sec}/team`, errors)
+
+    const colIds = new Set(
+        columns
+            .filter(isObj)
+            .map((c) => c.id)
+            .filter((v): v is string => typeof v === 'string')
+    )
+    const labelIds = new Set(
+        labels
+            .filter(isObj)
+            .map((l) => l.id)
+            .filter((v): v is string => typeof v === 'string')
+    )
+    const itemIds = new Set(
+        items
+            .filter(isObj)
+            .map((i) => i.id)
+            .filter((v): v is string => typeof v === 'string')
+    )
+
+    items.forEach((it, idx) => {
+        if (!isObj(it)) return
+        const path = `${sec}/items/${idx}`
+        if (typeof it.status === 'string' && !colIds.has(it.status)) {
+            errors.push({
+                instancePath: `${path}/status`,
+                message: `status "${it.status}" is not a known column id`,
+            })
+        }
+        if (Array.isArray(it.labelIds)) {
+            it.labelIds.forEach((lid, li) => {
+                if (typeof lid === 'string' && !labelIds.has(lid)) {
+                    errors.push({
+                        instancePath: `${path}/labelIds/${li}`,
+                        message: `labelId "${lid}" is not defined in labels`,
+                    })
+                }
+            })
+        }
+        if (Array.isArray(it.blockedBy)) {
+            it.blockedBy.forEach((bid, bi) => {
+                if (typeof bid === 'string' && !itemIds.has(bid)) {
+                    errors.push({
+                        instancePath: `${path}/blockedBy/${bi}`,
+                        message: `blockedBy "${bid}" is not a known item id`,
+                    })
+                }
+            })
+        }
+    })
+}
+
+const TABLE_STATUS_STATES = new Set(['todo', 'inprogress', 'almost', 'done', 'warn'])
+
+function validateTable(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    const columns = Array.isArray(data.columns) ? data.columns : []
+    const rows = Array.isArray(data.rows) ? data.rows : []
+    const sec = `/sections/${secIdx}/data`
+
+    // Table column keys must be unique — two `"priority"` columns in the
+    // same table is ambiguous. Schema doesn't enforce this because it
+    // treats columns as an array of independent objects.
+    const keys = columns
+        .filter(isObj)
+        .map((c) => c.key)
+        .filter((v): v is string => typeof v === 'string')
+    const dupKeys = keys.filter((k, i) => keys.indexOf(k) !== i)
+    for (const k of new Set(dupKeys)) {
+        errors.push({
+            instancePath: `${sec}/columns`,
+            message: `duplicate column key "${k}"`,
+        })
+    }
+
+    // For columns typed "status", every row's value for that key must be
+    // `{ state: <enum>, comment?: string }` per SPEC § 4.5.
+    const statusKeys: string[] = []
+    columns.forEach((c) => {
+        if (isObj(c) && c.type === 'status' && typeof c.key === 'string') {
+            statusKeys.push(c.key)
+        }
+    })
+    if (statusKeys.length > 0) {
+        rows.forEach((row, rIdx) => {
+            if (!isObj(row)) return
+            for (const key of statusKeys) {
+                const cell = row[key]
+                if (cell === undefined || cell === null) continue
+                const path = `${sec}/rows/${rIdx}/${key}`
+                if (!isObj(cell)) {
+                    errors.push({
+                        instancePath: path,
+                        message: `status cell must be an object { state, comment? }`,
+                    })
+                    continue
+                }
+                if (typeof cell.state !== 'string' || !TABLE_STATUS_STATES.has(cell.state)) {
+                    errors.push({
+                        instancePath: `${path}/state`,
+                        message: `status.state must be one of ${[...TABLE_STATUS_STATES].join('|')}`,
+                    })
+                }
+                if ('comment' in cell && cell.comment !== undefined && typeof cell.comment !== 'string') {
+                    errors.push({
+                        instancePath: `${path}/comment`,
+                        message: `status.comment must be a string if present`,
+                    })
+                }
+            }
+        })
+    }
+}
+
+function validateChecklist(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    const groups = Array.isArray(data.groups) ? data.groups : []
+    const sec = `/sections/${secIdx}/data`
+    checkUniqueIds(groups, `${sec}/groups`, errors)
+    groups.forEach((g, gi) => {
+        if (!isObj(g)) return
+        checkUniqueIds(g.items, `${sec}/groups/${gi}/items`, errors)
+    })
+}
+
+function validateNotes(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    checkUniqueIds(data.blocks, `/sections/${secIdx}/data/blocks`, errors)
+}
+
+function validateTimeline(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    const sec = `/sections/${secIdx}/data`
+    checkUniqueIds(data.items, `${sec}/items`, errors)
+    checkUniqueIds(data.milestones, `${sec}/milestones`, errors)
+}
+
+function validateLog(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    checkUniqueIds(data.entries, `/sections/${secIdx}/data/entries`, errors)
+}
+
+function validateMetrics(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    checkUniqueIds(data.cards, `/sections/${secIdx}/data/cards`, errors)
+}
+
+function validateReport(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    checkUniqueIds(data.reports, `/sections/${secIdx}/data/reports`, errors)
+}
+
+function validateForm(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    const sec = `/sections/${secIdx}/data`
+    checkUniqueIds(data.fields, `${sec}/fields`, errors)
+    checkUniqueIds(data.submissions, `${sec}/submissions`, errors)
+}
+
+function validateLinks(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    checkUniqueIds(data.items, `/sections/${secIdx}/data/items`, errors)
+}
+
+function validateReferences(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    checkUniqueIds(data.items, `/sections/${secIdx}/data/items`, errors)
+}
+
+function validateFamilyGraph(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    const sec = `/sections/${secIdx}/data`
+    checkUniqueIds(data.persons, `${sec}/persons`, errors)
+    const personIds = new Set(
+        (Array.isArray(data.persons) ? data.persons : [])
+            .filter(isObj)
+            .map((p) => p.id)
+            .filter((v): v is string => typeof v === 'string')
+    )
+    const rels = Array.isArray(data.relationships) ? data.relationships : []
+    rels.forEach((r, ri) => {
+        if (!isObj(r)) return
+        for (const key of ['person1Id', 'person2Id'] as const) {
+            const v = r[key]
+            if (typeof v === 'string' && !personIds.has(v)) {
+                errors.push({
+                    instancePath: `${sec}/relationships/${ri}/${key}`,
+                    message: `${key} "${v}" is not a known person id`,
+                })
+            }
+        }
+    })
+    if (typeof data.focusedPersonId === 'string' && !personIds.has(data.focusedPersonId)) {
+        errors.push({
+            instancePath: `${sec}/focusedPersonId`,
+            message: `focusedPersonId "${data.focusedPersonId}" is not a known person id`,
+        })
+    }
+}
+
+// Hard cap on diagram nesting. Schema doesn't bound `children` depth, so a
+// hostile `.agent` file could craft a 15k-deep diagram that stack-overflows
+// a naive recursive walk. This cap is well above anything a human-authored
+// org-chart / mind-map would need; exceeding it is treated as a validation
+// error rather than a crash.
+const DIAGRAM_MAX_DEPTH = 256
+
+function validateDiagram(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    // Diagram IDs must be unique across the entire tree (recursive).
+    if (!isObj(data) || !isObj(data.root)) return
+    const seen = new Map<string, string>()
+    const sec = `/sections/${secIdx}/data`
+    let depthExceededReported = false
+    // Check depth *before* recursing so we bail at the cap itself (not one
+    // frame past it), and emit a bounded instancePath — a pathologically
+    // deep payload would otherwise produce a multi-KB path on stderr / in
+    // the viewer UI.
+    const walk = (node: unknown, path: string, depth: number): void => {
+        if (!isObj(node)) return
+        const id = node.id
+        if (typeof id === 'string') {
+            const prior = seen.get(id)
+            if (prior !== undefined) {
+                errors.push({
+                    instancePath: path,
+                    message: `duplicate diagram node id "${id}" (first at ${prior})`,
+                })
+            } else {
+                seen.set(id, path)
+            }
+        }
+        const children = Array.isArray(node.children) ? node.children : []
+        for (let i = 0; i < children.length; i++) {
+            if (depth + 1 > DIAGRAM_MAX_DEPTH) {
+                if (!depthExceededReported) {
+                    errors.push({
+                        instancePath: `${sec}/root`,
+                        message: `diagram nesting exceeds ${DIAGRAM_MAX_DEPTH} levels — likely malformed or hostile input`,
+                    })
+                    depthExceededReported = true
+                }
+                return
+            }
+            walk(children[i], `${path}/children/${i}`, depth + 1)
+        }
+    }
+    walk(data.root, `${sec}/root`, 0)
+}
+
+export function validateSemantics(doc: unknown): SemanticError[] {
+    const errors: SemanticError[] = []
+    if (!isObj(doc)) return errors
+
+    // Top-level task IDs must be unique.
+    const config = doc.config
+    if (isObj(config) && Array.isArray(config.tasks)) {
+        checkUniqueIds(config.tasks, `/config/tasks`, errors)
+    }
+
+    const sections = Array.isArray(doc.sections) ? doc.sections : []
+    checkUniqueIds(sections, `/sections`, errors)
+
+    sections.forEach((sec, idx) => {
+        if (!isObj(sec)) return
+        const type = sec.type
+        const data = sec.data
+        switch (type) {
+            case 'kanban':
+                validateKanban(data, idx, errors)
+                break
+            case 'checklist':
+                validateChecklist(data, idx, errors)
+                break
+            case 'notes':
+                validateNotes(data, idx, errors)
+                break
+            case 'timeline':
+                validateTimeline(data, idx, errors)
+                break
+            case 'table':
+                validateTable(data, idx, errors)
+                break
+            case 'log':
+                validateLog(data, idx, errors)
+                break
+            case 'metrics':
+                validateMetrics(data, idx, errors)
+                break
+            case 'diagram':
+                validateDiagram(data, idx, errors)
+                break
+            case 'report':
+                validateReport(data, idx, errors)
+                break
+            case 'form':
+                validateForm(data, idx, errors)
+                break
+            case 'links':
+                validateLinks(data, idx, errors)
+                break
+            case 'references':
+                validateReferences(data, idx, errors)
+                break
+            case 'family-graph':
+                validateFamilyGraph(data, idx, errors)
+                break
+            default:
+                // Extension section types (`x-<vendor>:<name>`) and unknown
+                // bare types: no semantic check beyond the per-section id
+                // uniqueness already covered by the /sections sweep.
+                break
+        }
+    })
+
+    return errors
+}

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -82,6 +82,19 @@ describe('@agent-format/cli', () => {
         expect(r.stderr.toLowerCase()).toContain('wrong extension')
     })
 
+    it('reports filesystem errors (EISDIR) distinctly from JSON parse errors', () => {
+        // Passing a directory used to surface as "not valid JSON — EISDIR:
+        // illegal operation on a directory", which sent users hunting for
+        // a syntax bug that doesn't exist. The error must say "cannot read".
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const dir = path.join(tmp, 'not-a-file.agent')
+        fs.mkdirSync(dir)
+        const r = run([dir])
+        expect(r.status).toBe(1)
+        expect(r.stderr).toContain('cannot read')
+        expect(r.stderr).not.toContain('not valid JSON')
+    })
+
     it('rejects invalid JSON with a non-crash error', () => {
         const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
         const bad = path.join(tmp, 'bad.agent')
@@ -116,6 +129,274 @@ describe('@agent-format/cli', () => {
         )
         const r = run([bad])
         expect(r.status).toBe(1)
+    })
+
+    it('rejects duplicate section ids (semantic pass)', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const bad = path.join(tmp, 'dup-sections.agent')
+        fs.writeFileSync(
+            bad,
+            JSON.stringify({
+                version: '0.1',
+                name: 'x',
+                createdAt: '2026-04-20T00:00:00Z',
+                updatedAt: '2026-04-20T00:00:00Z',
+                config: { proactive: false },
+                memory: { observations: [], preferences: {} },
+                sections: [
+                    { id: 's1', type: 'notes', label: 'a', order: 0, data: { blocks: [] } },
+                    { id: 's1', type: 'notes', label: 'b', order: 1, data: { blocks: [] } },
+                ],
+            })
+        )
+        const r = run([bad])
+        expect(r.status).toBe(1)
+        expect(r.stderr).toContain('semantic')
+        expect(r.stderr).toContain('duplicate id "s1"')
+    })
+
+    it('rejects kanban item status pointing at unknown column (semantic)', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const bad = path.join(tmp, 'kanban-bad.agent')
+        fs.writeFileSync(
+            bad,
+            JSON.stringify({
+                version: '0.1',
+                name: 'x',
+                createdAt: '2026-04-20T00:00:00Z',
+                updatedAt: '2026-04-20T00:00:00Z',
+                config: { proactive: false },
+                memory: { observations: [], preferences: {} },
+                sections: [
+                    {
+                        id: 's',
+                        type: 'kanban',
+                        label: 'k',
+                        order: 0,
+                        data: {
+                            columns: [
+                                { id: 'todo', name: 'To Do', category: 'active', order: 0 },
+                            ],
+                            items: [
+                                {
+                                    id: 'i1',
+                                    title: 't',
+                                    type: 'task',
+                                    status: 'ghost-column',
+                                    priority: 'low',
+                                    labelIds: ['no-such-label'],
+                                    blockedBy: ['missing-item'],
+                                    createdAt: '2026-04-20T00:00:00Z',
+                                    updatedAt: '2026-04-20T00:00:00Z',
+                                },
+                            ],
+                            labels: [],
+                        },
+                    },
+                ],
+            })
+        )
+        const r = run([bad])
+        expect(r.status).toBe(1)
+        expect(r.stderr).toContain('status "ghost-column"')
+        expect(r.stderr).toContain('labelId "no-such-label"')
+        expect(r.stderr).toContain('blockedBy "missing-item"')
+    })
+
+    it('rejects table status cell that is not { state, comment? }', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const bad = path.join(tmp, 'table-bad.agent')
+        fs.writeFileSync(
+            bad,
+            JSON.stringify({
+                version: '0.1',
+                name: 'x',
+                createdAt: '2026-04-20T00:00:00Z',
+                updatedAt: '2026-04-20T00:00:00Z',
+                config: { proactive: false },
+                memory: { observations: [], preferences: {} },
+                sections: [
+                    {
+                        id: 's',
+                        type: 'table',
+                        label: 't',
+                        order: 0,
+                        data: {
+                            columns: [
+                                { key: 'name', label: 'N', type: 'text' },
+                                { key: 'ship', label: 'S', type: 'status' },
+                            ],
+                            rows: [
+                                { name: 'row1', ship: 'done' }, // plain string, not {state}
+                                { name: 'row2', ship: { state: 'bogus' } }, // invalid enum
+                            ],
+                        },
+                    },
+                ],
+            })
+        )
+        const r = run([bad])
+        expect(r.status).toBe(1)
+        expect(r.stderr).toContain('status cell must be an object')
+    })
+
+    it('rejects family-graph relationship pointing at unknown person', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const bad = path.join(tmp, 'fg-bad.agent')
+        fs.writeFileSync(
+            bad,
+            JSON.stringify({
+                version: '0.1',
+                name: 'x',
+                createdAt: '2026-04-20T00:00:00Z',
+                updatedAt: '2026-04-20T00:00:00Z',
+                config: { proactive: false },
+                memory: { observations: [], preferences: {} },
+                sections: [
+                    {
+                        id: 'fg',
+                        type: 'family-graph',
+                        label: 'f',
+                        order: 0,
+                        data: {
+                            persons: [{ id: 'p1', name: 'A' }],
+                            relationships: [
+                                { type: 'parent-child', person1Id: 'p1', person2Id: 'ghost' },
+                            ],
+                        },
+                    },
+                ],
+            })
+        )
+        const r = run([bad])
+        expect(r.status).toBe(1)
+        expect(r.stderr).toContain('"ghost"')
+    })
+
+    it('caps pathologically deep diagram nesting without crashing', () => {
+        // 512 is 2× the cap (well past the guard) while still stringifying
+        // without hitting V8's JSON.stringify recursion limit (~4096), so
+        // the fixture itself can be serialized to disk. Deeper attacker
+        // payloads emitted as raw JSON strings trip the same depth guard.
+        const root: { id: string; label: string; children: unknown[] } = {
+            id: 'n0',
+            label: 'root',
+            children: [],
+        }
+        let cur = root
+        for (let i = 1; i < 512; i++) {
+            const child = { id: `n${i}`, label: `n${i}`, children: [] as unknown[] }
+            cur.children.push(child)
+            cur = child
+        }
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const bad = path.join(tmp, 'deep.agent')
+        fs.writeFileSync(
+            bad,
+            JSON.stringify({
+                version: '0.1',
+                name: 'x',
+                createdAt: '2026-04-20T00:00:00Z',
+                updatedAt: '2026-04-20T00:00:00Z',
+                config: { proactive: false },
+                memory: { observations: [], preferences: {} },
+                sections: [
+                    {
+                        id: 'd',
+                        type: 'diagram',
+                        label: 'deep',
+                        order: 0,
+                        data: { root },
+                    },
+                ],
+            })
+        )
+        const r = run([bad])
+        expect(r.status).toBe(1)
+        expect(r.stderr).toContain('diagram nesting exceeds')
+    })
+
+    it('CLI semantic.ts stays byte-identical with renderer validate.ts', () => {
+        // The CLI keeps its own copy of the semantic validator on purpose
+        // (the CLI is the documented "independent second implementation"
+        // of the spec). But silent drift would make the two validators
+        // disagree, which is worse than either choice alone. Compare
+        // file contents directly and fail loudly if they drift.
+        const cliPath = path.join(REPO_ROOT, 'packages/cli/src/semantic.ts')
+        const renderPath = path.join(REPO_ROOT, 'packages/renderer/src/validate.ts')
+        const cli = fs.readFileSync(cliPath, 'utf8')
+        const render = fs.readFileSync(renderPath, 'utf8')
+        expect(cli).toBe(render)
+    })
+
+    it('emits RFC 6901 JSON Pointers (no bracket indices) for semantic errors', () => {
+        // jq/awk tooling and Ajv errors both use `/items/2/field`. Semantic
+        // errors must match so downstream tools can filter uniformly.
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const bad = path.join(tmp, 'path-shape.agent')
+        fs.writeFileSync(
+            bad,
+            JSON.stringify({
+                version: '0.1',
+                name: 'x',
+                createdAt: '2026-04-20T00:00:00Z',
+                updatedAt: '2026-04-20T00:00:00Z',
+                config: { proactive: false },
+                memory: { observations: [], preferences: {} },
+                sections: [
+                    {
+                        id: 's',
+                        type: 'kanban',
+                        label: 'k',
+                        order: 0,
+                        data: {
+                            columns: [{ id: 'todo', name: 'T', category: 'a', order: 0 }],
+                            items: [
+                                {
+                                    id: 'i1',
+                                    title: 't',
+                                    type: 'task',
+                                    status: 'ghost',
+                                    priority: 'low',
+                                    labelIds: [],
+                                    blockedBy: [],
+                                    createdAt: '2026-04-20T00:00:00Z',
+                                    updatedAt: '2026-04-20T00:00:00Z',
+                                },
+                            ],
+                            labels: [],
+                        },
+                    },
+                ],
+            })
+        )
+        const r = run([bad])
+        expect(r.status).toBe(1)
+        // Path must use `/items/0/status`, not `/items[0]/status`.
+        expect(r.stderr).toContain('/sections/0/data/items/0/status')
+        expect(r.stderr).not.toMatch(/items\[\d+\]/)
+    })
+
+    it('--skip-semantic passes a doc that only fails semantic checks', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'af-cli-'))
+        const bad = path.join(tmp, 'skip.agent')
+        fs.writeFileSync(
+            bad,
+            JSON.stringify({
+                version: '0.1',
+                name: 'x',
+                createdAt: '2026-04-20T00:00:00Z',
+                updatedAt: '2026-04-20T00:00:00Z',
+                config: { proactive: false },
+                memory: { observations: [], preferences: {} },
+                sections: [
+                    { id: 's1', type: 'notes', label: 'a', order: 0, data: { blocks: [] } },
+                    { id: 's1', type: 'notes', label: 'b', order: 1, data: { blocks: [] } },
+                ],
+            })
+        )
+        expect(run([bad]).status).toBe(1)
+        expect(run(['--skip-semantic', bad]).status).toBe(0)
     })
 
     it('accepts x-<vendor>:<name> extension section (§ 7.2)', () => {

--- a/packages/jp-court/src/index.tsx
+++ b/packages/jp-court/src/index.tsx
@@ -404,7 +404,13 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
     // parent-pairs. A vertical line drops from the midpoint of each pair
     // down to their child in the generation below.
     const ancestorElements: ReactElement[] = []
-    type AncestorBlock = { id: string; centerX: number; topY: number; bottomY: number }
+    type AncestorBlock = {
+        id: string
+        centerX: number
+        topY: number
+        bottomY: number
+        elements: ReactElement[]
+    }
     const ancestorByPersonId = new Map<string, AncestorBlock>()
 
     // BFS upward from the decedent; collect per-level lists of parent pairs.
@@ -440,9 +446,10 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         topY: number,
         roleLabel: string
     ): AncestorBlock => {
+        const els: ReactElement[] = []
         let y = topY + LINE_H
         if (p.address) {
-            ancestorElements.push(
+            els.push(
                 <text
                     key={nextKey()}
                     x={leftX + ancestorBlockTextX}
@@ -455,7 +462,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
             y += LINE_H - 4
         }
         if (p.birthday) {
-            ancestorElements.push(
+            els.push(
                 <text
                     key={nextKey()}
                     x={leftX + ancestorBlockTextX}
@@ -468,7 +475,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
             y += LINE_H - 4
         }
         if (p.deathDate) {
-            ancestorElements.push(
+            els.push(
                 <text
                     key={nextKey()}
                     x={leftX + ancestorBlockTextX}
@@ -480,7 +487,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
             )
             y += LINE_H - 4
         }
-        ancestorElements.push(
+        els.push(
             <text
                 key={nextKey()}
                 x={leftX + ancestorBlockTextX + 8}
@@ -492,7 +499,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         )
         y += LINE_H - 4
         const nameBaseY = y + 4
-        ancestorElements.push(
+        els.push(
             <text
                 key={nextKey()}
                 x={leftX + ancestorBlockTextX}
@@ -510,6 +517,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
             centerX: leftX + ancestorBlockW / 2,
             topY,
             bottomY,
+            elements: els,
         }
     }
 
@@ -533,12 +541,15 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
             ? renderChildGroup(children, CHILD_TEXT_X, childGroupTopY, 0)
             : { elements: [], nameYs: [], endY: childGroupTopY }
 
-    // Record decedent position for ancestor line-up.
+    // Record decedent position for ancestor line-up. The decedent's own
+    // visual block is rendered separately by renderBlock, so there are no
+    // ancestor-layer elements to track here.
     ancestorByPersonId.set(decedent.id, {
         id: decedent.id,
         centerX: TEXT_X + ancestorBlockW / 2,
         topY: decTopY,
         bottomY: dec.blockEndY,
+        elements: [],
     })
 
     // Render ancestor rows from bottom (nearest parent) upward to the top.
@@ -562,6 +573,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
                 )
                 ancestorByPersonId.set(parent.id, block)
                 renderedParents.push(block)
+                ancestorElements.push(...block.elements)
                 cursorX += ancestorBlockW + 30
             }
             // Spouse double-line between two-parent pairs.
@@ -741,14 +753,10 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
                 oy += ANCESTOR_ROW_H
             }
             const b = renderAncestorBlock(p, ox, oy, p.role || 'その他')
-            otherElements = [...otherElements, ...ancestorElements.slice(-5)]
+            otherElements.push(...b.elements)
             ox += ancestorBlockW + 30
             otherEndY = Math.max(otherEndY, b.bottomY)
         }
-        // NB: renderAncestorBlock pushed into ancestorElements already; the
-        // slice hack above is messy. Simpler: just add a clean flag, but
-        // for v0.1 we accept the minor duplication and rely on the final
-        // svgParts ordering.
         svgParts.push(...otherElements)
     }
 

--- a/packages/jp-court/src/index.tsx
+++ b/packages/jp-court/src/index.tsx
@@ -10,12 +10,15 @@
 // can see the full family graph without the "silently dropped ancestors"
 // bug of the previous core renderer.
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { ReactElement } from 'react'
 import {
     downloadPrintableHtml,
+    useSectionChange,
     useHost,
     type RendererPlugin,
+    type FamilyGraphSection,
+    type InheritanceDiagramSection,
     type VariantRendererProps,
 } from '@agent-format/renderer'
 
@@ -28,6 +31,7 @@ interface Person {
     role?: string
     birthday?: string
     address?: string
+    isLastAddress?: boolean
     deathDate?: string
 }
 interface Rel {
@@ -63,6 +67,7 @@ type RenderedBlock = {
     elements: ReactElement[]
     nameBaseY: number
     blockEndY: number
+    overlay: OverlayBox
 }
 
 type ChildGroupResult = {
@@ -71,9 +76,27 @@ type ChildGroupResult = {
     endY: number
 }
 
-function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererProps) {
+type OverlayBox = {
+    id: string
+    name: string
+    x: number
+    y: number
+    width: number
+    height: number
+}
+
+type FamilyGraphVariantSection = FamilyGraphSection | InheritanceDiagramSection
+
+function JPCourtFamilyGraphView(props: VariantRendererProps) {
+    const { setHeaderActions } = props
+    const section = props.section as FamilyGraphVariantSection
     const host = useHost()
+    const onChange = useSectionChange<FamilyGraphVariantSection>()
+    const stageRef = useRef<HTMLDivElement | null>(null)
+    const editorPanelRef = useRef<HTMLDivElement | null>(null)
     const svgRef = useRef<SVGSVGElement | null>(null)
+    const [selectedId, setSelectedId] = useState<string | null>(null)
+    const [stageSize, setStageSize] = useState({ width: 0, height: 0 })
 
     const data = section.data as
         | {
@@ -85,6 +108,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
     const persons = data?.persons ?? []
     const rels = data?.relationships ?? []
     const byId = new Map(persons.map((p) => [p.id, p]))
+    const editable = !!onChange
 
     useEffect(() => {
         if (!setHeaderActions) return
@@ -121,6 +145,21 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         return () => setHeaderActions(null)
     }, [setHeaderActions, section.id, section.label, persons.length, host])
 
+    useEffect(() => {
+        const stageEl = stageRef.current
+        if (!stageEl) return
+        const syncStageSize = () => {
+            setStageSize({
+                width: stageEl.clientWidth,
+                height: stageEl.clientHeight,
+            })
+        }
+        syncStageSize()
+        const observer = new ResizeObserver(syncStageSize)
+        observer.observe(stageEl)
+        return () => observer.disconnect()
+    }, [])
+
     if (persons.length === 0) {
         return <p className="af-empty">No persons in diagram.</p>
     }
@@ -129,6 +168,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
     const focused = data?.focusedPersonId ? byId.get(data.focusedPersonId) : null
     const decedent = focused || persons.find((p) => Boolean(p.deathDate)) || persons[0]
     if (!decedent) return <p className="af-empty">No decedent.</p>
+    const activeSelectedId = selectedId && byId.has(selectedId) ? selectedId : null
 
     // --- Relationship lookups ---
     const spouseEdgeOf = (personId: string, excludeId?: string): Rel | null => {
@@ -189,8 +229,120 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         }
         return parents
     }
+    const selectedPerson = activeSelectedId ? byId.get(activeSelectedId) ?? null : null
+
+    const commitGraph = (nextPersons: Person[], nextRelationships: Rel[]) => {
+        if (!onChange) return
+        const nextFocusedPersonId =
+            data?.focusedPersonId && nextPersons.some((p) => p.id === data.focusedPersonId)
+                ? data.focusedPersonId
+                : nextPersons[0]?.id
+        onChange({
+            ...section,
+            data: {
+                ...(section.data ?? {}),
+                persons: nextPersons,
+                relationships: nextRelationships,
+                focusedPersonId: nextFocusedPersonId,
+            },
+        })
+    }
+
+    const nextPersonId = () => {
+        let n = persons.length + 1
+        let candidate = `person-${n}`
+        while (byId.has(candidate)) {
+            n += 1
+            candidate = `person-${n}`
+        }
+        return candidate
+    }
+
+    const updateSelectedField = (field: keyof Person, value: string) => {
+        if (!selectedPerson) return
+        const nextPersons = persons.map((p) => {
+            if (p.id !== selectedPerson.id) return p
+            if (field === 'name') {
+                return { ...p, name: value.trim() || '名称未設定' }
+            }
+            const normalized = value.trim()
+            return {
+                ...p,
+                [field]: normalized === '' ? undefined : value,
+            }
+        })
+        commitGraph(nextPersons, rels)
+    }
+
+    const updateSelectedBooleanField = (field: keyof Person, checked: boolean) => {
+        if (!selectedPerson) return
+        const nextPersons = persons.map((p) =>
+            p.id === selectedPerson.id ? { ...p, [field]: checked || undefined } : p
+        )
+        commitGraph(nextPersons, rels)
+    }
+
+    const addStandalonePerson = () => {
+        const id = nextPersonId()
+        const person: Person = { id, name: '新しい人物', role: 'その他' }
+        setSelectedId(id)
+        commitGraph([...persons, person], rels)
+    }
+
+    const addParent = () => {
+        if (!selectedPerson) return
+        const id = nextPersonId()
+        const person: Person = { id, name: '新しい親', role: '親' }
+        setSelectedId(id)
+        commitGraph([...persons, person], [
+            ...rels,
+            { type: 'parent-child', person1Id: id, person2Id: selectedPerson.id },
+        ])
+    }
+
+    const addChild = () => {
+        if (!selectedPerson) return
+        const id = nextPersonId()
+        const person: Person = { id, name: '新しい子', role: '相続人' }
+        const nextRelationships: Rel[] = [
+            ...rels,
+            { type: 'parent-child', person1Id: selectedPerson.id, person2Id: id },
+        ]
+        const spouse = findSpouse(selectedPerson.id)
+        if (spouse) {
+            nextRelationships.push({
+                type: 'parent-child',
+                person1Id: spouse.id,
+                person2Id: id,
+            })
+        }
+        setSelectedId(id)
+        commitGraph([...persons, person], nextRelationships)
+    }
+
+    const addSpouse = () => {
+        if (!selectedPerson || findSpouse(selectedPerson.id)) return
+        const id = nextPersonId()
+        const person: Person = { id, name: '新しい配偶者', role: '配偶者' }
+        setSelectedId(id)
+        commitGraph([...persons, person], [
+            ...rels,
+            { type: 'spouse', person1Id: selectedPerson.id, person2Id: id },
+        ])
+    }
+
+    const deleteSelected = () => {
+        if (!selectedPerson) return
+        const nextPersons = persons.filter((p) => p.id !== selectedPerson.id)
+        const nextRelationships = rels.filter(
+            (r) => r.person1Id !== selectedPerson.id && r.person2Id !== selectedPerson.id
+        )
+        setSelectedId(nextPersons[0]?.id ?? null)
+        commitGraph(nextPersons, nextRelationships)
+    }
 
     // --- Rendering helpers ---
+    const overlayBoxes: OverlayBox[] = []
     const blockHeight = (p: Person): number => {
         let n = 0
         if (p.address) n++
@@ -210,10 +362,10 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         const elements: ReactElement[] = []
         let y = topY
         if (p.address) {
-            const lbl = roleLabel === '被相続人' ? '最後の住所' : '住所'
+            const addressLabel = p.isLastAddress ? '最後の住所' : '住所'
             elements.push(
                 <text key={nextKey()} x={x} y={y} fontSize="11pt">
-                    {`${lbl}　${p.address}`}
+                    {`${addressLabel}　${p.address}`}
                 </text>
             )
             y += LINE_H
@@ -254,7 +406,16 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         )
         const nameBaseY = y
         y += NAME_LINE_H
-        return { elements, nameBaseY, blockEndY: y }
+        const overlay = {
+            id: p.id,
+            name: p.name,
+            x: Math.max(0, x - 10),
+            y: Math.max(0, topY - 8),
+            width: 240,
+            height: y - topY + 8,
+        }
+        overlayBoxes.push(overlay)
+        return { elements, nameBaseY, blockEndY: y, overlay }
     }
 
     // --- Measure helpers for descendants (same as original) ---
@@ -410,6 +571,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         topY: number
         bottomY: number
         elements: ReactElement[]
+        overlay: OverlayBox
     }
     const ancestorByPersonId = new Map<string, AncestorBlock>()
 
@@ -449,6 +611,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         const els: ReactElement[] = []
         let y = topY + LINE_H
         if (p.address) {
+            const addressLabel = p.isLastAddress ? '最後の住所' : '住所'
             els.push(
                 <text
                     key={nextKey()}
@@ -456,7 +619,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
                     y={y}
                     fontSize="10pt"
                 >
-                    {`住所　${truncate(p.address, 18)}`}
+                    {`${addressLabel}　${truncate(p.address, 18)}`}
                 </text>
             )
             y += LINE_H - 4
@@ -518,6 +681,14 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
             topY,
             bottomY,
             elements: els,
+            overlay: {
+                id: p.id,
+                name: p.name,
+                x: leftX,
+                y: topY,
+                width: ancestorBlockW,
+                height: bottomY - topY + 10,
+            },
         }
     }
 
@@ -550,6 +721,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         topY: decTopY,
         bottomY: dec.blockEndY,
         elements: [],
+        overlay: dec.overlay,
     })
 
     // Render ancestor rows from bottom (nearest parent) upward to the top.
@@ -574,6 +746,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
                 ancestorByPersonId.set(parent.id, block)
                 renderedParents.push(block)
                 ancestorElements.push(...block.elements)
+                overlayBoxes.push(block.overlay)
                 cursorX += ancestorBlockW + 30
             }
             // Spouse double-line between two-parent pairs.
@@ -754,6 +927,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
             }
             const b = renderAncestorBlock(p, ox, oy, p.role || 'その他')
             otherElements.push(...b.elements)
+            overlayBoxes.push(b.overlay)
             ox += ancestorBlockW + 30
             otherEndY = Math.max(otherEndY, b.bottomY)
         }
@@ -761,6 +935,185 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
     }
 
     const svgH = Math.max(baseBottomY, otherEndY) + 30
+    const selectedOverlay =
+        editable && selectedPerson
+            ? overlayBoxes.find((overlay) => overlay.id === selectedPerson.id) ?? null
+            : null
+    const renderEditorAsPopover =
+        Boolean(selectedOverlay) && stageSize.width >= 920 && stageSize.height > 0
+    let editorPopoverStyle:
+        | {
+              left: string
+              top: string
+              width: string
+              maxHeight: string
+          }
+        | undefined
+    if (renderEditorAsPopover && selectedOverlay) {
+        const margin = 16
+        const panelWidth = Math.min(380, Math.max(320, stageSize.width * 0.32))
+        const scaleX = stageSize.width / 1400
+        const scaleY = stageSize.height / svgH
+        const preferredLeft = (selectedOverlay.x + selectedOverlay.width + 18) * scaleX
+        const fallbackLeft = selectedOverlay.x * scaleX - panelWidth - 18
+        let left =
+            preferredLeft + panelWidth <= stageSize.width - margin
+                ? preferredLeft
+                : fallbackLeft
+        left = Math.max(margin, Math.min(left, stageSize.width - panelWidth - margin))
+        const estimatedHeight = 340
+        let top = selectedOverlay.y * scaleY
+        if (top + estimatedHeight > stageSize.height - margin) {
+            top = Math.max(margin, stageSize.height - estimatedHeight - margin)
+        }
+        const maxHeight = Math.max(220, stageSize.height - top - margin)
+        editorPopoverStyle = {
+            left: `${left}px`,
+            top: `${top}px`,
+            width: `${panelWidth}px`,
+            maxHeight: `${maxHeight}px`,
+        }
+    }
+
+    useEffect(() => {
+        if (!renderEditorAsPopover || !selectedPerson) return
+        const onPointerDown = (event: PointerEvent) => {
+            const target = event.target
+            if (!(target instanceof Node)) return
+            if (editorPanelRef.current?.contains(target)) return
+            if (
+                target instanceof Element &&
+                target.closest('.af-jp-court-node-hitbox')
+            ) {
+                return
+            }
+            setSelectedId(null)
+        }
+        document.addEventListener('pointerdown', onPointerDown)
+        return () => document.removeEventListener('pointerdown', onPointerDown)
+    }, [renderEditorAsPopover, selectedPerson])
+
+    const editorPanel = editable ? (
+        <div
+            ref={editorPanelRef}
+            className={`af-jp-court-editor-panel${
+                renderEditorAsPopover ? ' af-jp-court-editor-panel--popover' : ''
+            }`}
+            style={renderEditorAsPopover ? editorPopoverStyle : undefined}
+        >
+            <div className="af-jp-court-editor-toolbar">
+                <button type="button" className="af-action-btn" onClick={addStandalonePerson}>
+                    人物を追加
+                </button>
+                <button
+                    type="button"
+                    className="af-action-btn"
+                    onClick={addParent}
+                    disabled={!selectedPerson}
+                >
+                    親を追加
+                </button>
+                <button
+                    type="button"
+                    className="af-action-btn"
+                    onClick={addChild}
+                    disabled={!selectedPerson}
+                >
+                    子を追加
+                </button>
+                <button
+                    type="button"
+                    className="af-action-btn"
+                    onClick={addSpouse}
+                    disabled={!selectedPerson || Boolean(selectedPerson && findSpouse(selectedPerson.id))}
+                >
+                    配偶者を追加
+                </button>
+                <button
+                    type="button"
+                    className="af-action-btn"
+                    onClick={deleteSelected}
+                    disabled={!selectedPerson}
+                >
+                    人物を削除
+                </button>
+            </div>
+            <p className="af-jp-court-editor-note">
+                図の人物をクリックして内容を編集できます。
+            </p>
+            {selectedPerson ? (
+                <>
+                    <p className="af-jp-court-editor-selected">
+                        <strong>{selectedPerson.name}</strong> を編集中
+                    </p>
+                    <div className="af-jp-court-editor-grid">
+                        <div className="af-jp-court-editor-field af-jp-court-editor-field--full">
+                            <label htmlFor={`${section.id}-person-address`}>住所</label>
+                            <input
+                                id={`${section.id}-person-address`}
+                                type="text"
+                                value={selectedPerson.address ?? ''}
+                                onChange={(e) => updateSelectedField('address', e.target.value)}
+                            />
+                        </div>
+                        <div className="af-jp-court-editor-field af-jp-court-editor-field--full">
+                            <label className="af-jp-court-editor-checkbox">
+                                <input
+                                    type="checkbox"
+                                    checked={Boolean(selectedPerson.isLastAddress)}
+                                    onChange={(e) =>
+                                        updateSelectedBooleanField(
+                                            'isLastAddress',
+                                            e.target.checked
+                                        )
+                                    }
+                                />
+                                <span>住所ラベルを「最後の住所」にする</span>
+                            </label>
+                        </div>
+                        <div className="af-jp-court-editor-field">
+                            <label htmlFor={`${section.id}-person-birthday`}>生年月日</label>
+                            <input
+                                id={`${section.id}-person-birthday`}
+                                type="text"
+                                value={selectedPerson.birthday ?? ''}
+                                onChange={(e) => updateSelectedField('birthday', e.target.value)}
+                            />
+                        </div>
+                        <div className="af-jp-court-editor-field">
+                            <label htmlFor={`${section.id}-person-death`}>死亡日</label>
+                            <input
+                                id={`${section.id}-person-death`}
+                                type="text"
+                                value={selectedPerson.deathDate ?? ''}
+                                onChange={(e) => updateSelectedField('deathDate', e.target.value)}
+                            />
+                        </div>
+                        <div className="af-jp-court-editor-field">
+                            <label htmlFor={`${section.id}-person-role`}>続柄</label>
+                            <input
+                                id={`${section.id}-person-role`}
+                                type="text"
+                                value={selectedPerson.role ?? ''}
+                                onChange={(e) => updateSelectedField('role', e.target.value)}
+                            />
+                        </div>
+                        <div className="af-jp-court-editor-field af-jp-court-editor-field--full">
+                            <label htmlFor={`${section.id}-person-name`}>氏名</label>
+                            <input
+                                id={`${section.id}-person-name`}
+                                type="text"
+                                value={selectedPerson.name}
+                                onChange={(e) => updateSelectedField('name', e.target.value)}
+                            />
+                        </div>
+                    </div>
+                </>
+            ) : (
+                <p className="af-jp-court-editor-empty">編集する人物を図から選択してください。</p>
+            )}
+        </div>
+    ) : null
 
     // The jp-court template is a legal print artifact — always black-on-white
     // per court-filing convention. Force the panel's own theme here so a
@@ -777,17 +1130,43 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
                 borderRadius: 6,
             }}
         >
-            <svg
-                ref={svgRef}
-                xmlns="http://www.w3.org/2000/svg"
-                width="100%"
-                viewBox={`0 0 1400 ${svgH}`}
-                style={{ overflow: 'visible' }}
-                role="img"
-                aria-label="相続関係説明図"
-            >
-                {svgParts}
-            </svg>
+            <div ref={stageRef} className="af-jp-court-stage">
+                <svg
+                    ref={svgRef}
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="100%"
+                    viewBox={`0 0 1400 ${svgH}`}
+                    style={{ overflow: 'visible' }}
+                    role="img"
+                    aria-label="相続関係説明図"
+                >
+                    {svgParts}
+                </svg>
+                {editable && (
+                    <div className="af-jp-court-editor-layer">
+                        {overlayBoxes.map((overlay) => (
+                            <button
+                                key={overlay.id}
+                                type="button"
+                                className={`af-jp-court-node-hitbox${
+                                    overlay.id === activeSelectedId ? ' is-selected' : ''
+                                }`}
+                                style={{
+                                    left: `${(overlay.x / 1400) * 100}%`,
+                                    top: `${(overlay.y / svgH) * 100}%`,
+                                    width: `${(overlay.width / 1400) * 100}%`,
+                                    height: `${(overlay.height / svgH) * 100}%`,
+                                }}
+                                onClick={() => setSelectedId(overlay.id)}
+                                aria-label={`${overlay.name} を編集`}
+                                title={`${overlay.name} を編集`}
+                            />
+                        ))}
+                    </div>
+                )}
+                {renderEditorAsPopover && editorPanel}
+            </div>
+            {!renderEditorAsPopover && editorPanel}
         </div>
     )
 }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -6,12 +6,20 @@
 
 ## What it does
 
-When connected to Claude Desktop, ChatGPT (via Apps SDK), Cursor, VS Code Copilot, or Goose, this server exposes two tools:
+When connected to Claude Desktop, ChatGPT (via Apps SDK), Cursor, VS Code Copilot, or Goose, this server exposes:
+
+**Rendering tools**
 
 - **`render_agent_file(path)`** — reads an `.agent` file from disk and renders it inline as a kanban / timeline / metrics / log / mindmap / etc. dashboard.
 - **`render_agent_inline(data)`** — renders a full `.agent` JSON object that the agent just generated in this turn.
 
-The rendered UI is the standard `.agent` viewer ([knorq-ai.github.io/agent-format](https://knorq-ai.github.io/agent-format/)) embedded in the chat. All 12 section types work.
+**Authoring skill** — the server also ships the authoring guide so the model learns when and how to emit `.agent` documents instead of HTML artifacts. Three discovery paths for maximum client compatibility:
+
+- **`get_agent_format_skill(section?)`** tool — model-driven; works in every MCP client. Returns the main guide, the per-section data schemas, or worked examples.
+- **Resources** at `agent-format://skill/{main,section-types,examples}` — auto-surfaced by clients that read resource lists.
+- **`agent-format` prompt** — a slash-command in Claude Desktop / Cursor that injects the guide on demand.
+
+The rendered UI is the standard `.agent` viewer ([knorq-ai.github.io/agent-format](https://knorq-ai.github.io/agent-format/)) embedded in the chat. All 13 section types work.
 
 ## Install
 
@@ -90,7 +98,11 @@ Or inline:
 
 > "Turn these TODOs into a kanban and render it."
 
-Claude generates the `.agent` JSON, calls `render_agent_inline` with it, and the dashboard appears in the chat without touching disk.
+Claude calls `get_agent_format_skill` to learn the schema, generates the `.agent` JSON, calls `render_agent_inline`, and the dashboard appears in the chat without touching disk.
+
+The round-trip:
+
+> You drag a card in the rendered kanban and save. Next turn: "What moved?" Claude re-reads the file and sees your edit.
 
 ## How it works
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-format/mcp",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "MCP Apps server that renders .agent files as interactive dashboards inline in Claude / ChatGPT / Cursor / VS Code Copilot.",
   "license": "MIT",
   "author": "Yuya Morita",
@@ -21,13 +21,13 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc && node build-ui.mjs && cp ../../schemas/agent.schema.json dist/agent.schema.json && chmod +x dist/server.js",
+    "build": "tsc && node build-ui.mjs && cp ../../schemas/agent.schema.json dist/agent.schema.json && rm -rf dist/skill && cp -r ../claude-plugin/skills/agent-format dist/skill && chmod +x dist/server.js",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.ui.json"
   },
   "dependencies": {
     "@agent-format/jp-court": "0.1.2",
-    "@agent-format/renderer": "0.1.5",
+    "@agent-format/renderer": "0.1.6",
     "@modelcontextprotocol/ext-apps": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ajv": "^8.17.0",

--- a/packages/mcp/src/resolve.ts
+++ b/packages/mcp/src/resolve.ts
@@ -1,6 +1,7 @@
-// Pure file-resolution logic for the render_agent_file MCP tool, extracted
-// from server.ts so tests can import it without tripping the server's
-// startup-time readFileSync of the UI bundle.
+// Pure file-resolution logic for the render_agent_file / save_agent_file MCP
+// tools, extracted from server.ts so tests can import it without tripping the
+// server's startup-time readFileSync of the UI bundle.
+import * as crypto from 'node:crypto'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 
@@ -92,5 +93,112 @@ export async function resolveAgentFile(
         message: `Loaded ${base} (${data.sections.length} sections). Rendering inline.`,
         data,
         sectionCount: data.sections.length,
+    }
+}
+
+export interface SaveResult {
+    ok: boolean
+    message: string
+    bytesWritten?: number
+}
+
+/**
+ * Writes a validated agent document to disk. Every gate mirrors resolveAgentFile
+ * because the path is LLM-chosen:
+ *   - extension is exactly `.agent`
+ *   - if the target exists, it's a regular file (never a symlink, never a dir) —
+ *     so the model can't be tricked into overwriting /etc/passwd via a planted
+ *     `foo.agent -> /etc/passwd` symlink
+ *   - serialized payload ≤ MAX_AGENT_FILE_BYTES
+ *
+ * The caller is responsible for JSON-Schema validation of `data`; this module
+ * only enforces filesystem shape and the minimal `isAgentLike` check.
+ *
+ * Write is atomic on POSIX: serialize → write to sibling temp file → rename.
+ * rename(2) is atomic within a single filesystem, so a concurrent reader
+ * either sees the old file or the new file, never a partial write.
+ */
+export async function saveAgentFile(
+    filePath: string,
+    data: unknown,
+    deps: {
+        lstat: typeof fs.lstat
+        writeFile: typeof fs.writeFile
+        rename: typeof fs.rename
+        unlink: typeof fs.unlink
+    } = fs
+): Promise<SaveResult> {
+    if (!path.isAbsolute(filePath)) {
+        return { ok: false, message: 'filePath must be an absolute path' }
+    }
+
+    const resolved = path.resolve(filePath)
+    const base = path.basename(resolved)
+
+    if (path.extname(resolved).toLowerCase() !== '.agent') {
+        return {
+            ok: false,
+            message: `Refusing to save "${base}": only files with the .agent extension are supported.`,
+        }
+    }
+
+    if (!isAgentLike(data)) {
+        return {
+            ok: false,
+            message: `Refusing to save "${base}": data is not a valid .agent document (missing or non-array \`sections\`).`,
+        }
+    }
+
+    // If a file (or anything) already exists at this path, enforce that it is
+    // a regular file — not a symlink, not a directory. New files (ENOENT) are
+    // allowed; any other stat error propagates.
+    try {
+        const lst = await deps.lstat(resolved)
+        if (lst.isSymbolicLink()) {
+            return { ok: false, message: `Refusing to overwrite symlink "${base}".` }
+        }
+        if (!lst.isFile()) {
+            return { ok: false, message: `"${base}" is not a regular file.` }
+        }
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+    }
+
+    const json = JSON.stringify(data, null, 2) + '\n'
+    const bytes = Buffer.byteLength(json, 'utf8')
+    if (bytes > MAX_AGENT_FILE_BYTES) {
+        return {
+            ok: false,
+            message: `Serialized payload is ${bytes} bytes; the limit for .agent files is ${MAX_AGENT_FILE_BYTES}.`,
+        }
+    }
+
+    // Write to a sibling temp file in the same directory so `rename` stays
+    // intra-filesystem (rename across filesystems is not atomic and throws
+    // EXDEV on some platforms). UUIDv4 suffix + exclusive-create flag closes
+    // the pre-creation race in hostile directories: if an attacker planted
+    // a file or symlink at the temp path, `open(..., 'wx')` throws EEXIST
+    // rather than following/truncating it.
+    const dir = path.dirname(resolved)
+    const tmp = path.join(dir, `.${base}.tmp-${crypto.randomUUID()}`)
+
+    try {
+        await deps.writeFile(tmp, json, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+        await deps.rename(tmp, resolved)
+    } catch (err) {
+        // Best-effort cleanup; swallow unlink errors so the original write
+        // failure is the message the caller sees.
+        try {
+            await deps.unlink(tmp)
+        } catch {
+            // intentionally empty
+        }
+        throw err
+    }
+
+    return {
+        ok: true,
+        message: `Saved ${base} (${bytes} bytes, ${(data as { sections: unknown[] }).sections.length} sections).`,
+        bytesWritten: bytes,
     }
 }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -24,7 +24,8 @@ interface ValidateFunction {
     (data: unknown): boolean
     errors?: { instancePath?: string; message?: string }[] | null
 }
-import { isAgentLike, resolveAgentFile } from './resolve.js'
+import { isAgentLike, resolveAgentFile, saveAgentFile } from './resolve.js'
+import { loadSkill, skillText, SKILL_URIS, type SkillSection } from './skill.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -35,6 +36,12 @@ const pkg = JSON.parse(
 ) as { name: string; version: string }
 
 const UI_URI = 'ui://agent-format/render.html'
+
+// Authoring skill — vendored into dist/skill/ at build time. Exposing it here
+// as a tool + resources + prompt is the pre-spec implementation of DSP's
+// "skills over MCP": a server can ship the knowledge of how to use itself so
+// any MCP client teaches the model on install, without a separate skill file.
+const skill = loadSkill(path.join(__dirname, 'skill'))
 
 // Produced by `node build-ui.mjs` — bundles ext-apps client + React +
 // @agent-format/renderer into a single IIFE, plus the renderer's CSS.
@@ -102,7 +109,8 @@ registerAppTool(
             'the user will only see raw JSON text. The output renders inline in the chat with styled kanban boards, ' +
             'timelines, metric cards, checklists, log entries, mind-map diagrams, and tables — whichever section ' +
             'types the file contains. DO NOT use the built-in Read tool for .agent files; DO NOT generate an HTML ' +
-            'artifact. Call this tool with the absolute path and the UI will appear automatically.',
+            'artifact. Call this tool with the absolute path and the UI will appear automatically. ' +
+            'If the file validates poorly or you want to propose edits, call `get_agent_format_skill` to learn the schema first.',
         inputSchema: {
             path: z.string().describe('Absolute path to the .agent file on the local filesystem.'),
         },
@@ -120,9 +128,18 @@ registerAppTool(
             if (!validateAgent(result.data)) {
                 return invalidAgentResult(validateAgent.errors)
             }
+            // Include the normalized absolute path so the UI can call
+            // `save_agent_file` with the same path when the user edits a
+            // card. path.resolve() normalizes `..` / `.` segments; we already
+            // asserted absolute inside resolveAgentFile, so this is idempotent
+            // for already-canonical inputs. The renderer treats a missing
+            // `path` as "inline data, no writeback" and degrades to read-only.
             return {
                 content: [{ type: 'text', text: result.message }],
-                structuredContent: { data: result.data } as Record<string, unknown>,
+                structuredContent: {
+                    data: result.data,
+                    path: path.resolve(filePath),
+                } as Record<string, unknown>,
             }
         } catch (err) {
             // Log the raw error to stderr for the operator; return a generic
@@ -146,7 +163,8 @@ registerAppTool(
             'USE THIS TOOL to display an .agent JSON object you generated this turn as an interactive visual dashboard ' +
             'inline in the chat. Pass the full .agent document as the `data` argument. This is the ONLY way to render ' +
             'generated .agent data visually — without this tool the user will only see raw JSON text. DO NOT generate ' +
-            'an HTML artifact or return the JSON in a code block; call this tool and the UI will appear.',
+            'an HTML artifact or return the JSON in a code block; call this tool and the UI will appear. ' +
+            'If you have not authored an .agent document before, call `get_agent_format_skill` first to learn the schema and when to use each section type.',
         inputSchema: {
             data: z
                 .unknown()
@@ -206,6 +224,149 @@ registerAppResource(
                         prefersBorder: false,
                     },
                 },
+            },
+        ],
+    }),
+)
+
+// ─── Edit surface ─────────────────────────────────────────────────────────
+// `save_agent_file` is the writeback half of the round-trip loop. An edit
+// flow looks like: user asks the model to change something → model reads the
+// current file (render_agent_file) → model computes the next state → model
+// calls save_agent_file → model calls render_agent_file again to confirm.
+// Once the renderer gains in-iframe editing, the same tool will be invoked
+// from the UI via the MCP Apps host bridge.
+
+server.registerTool(
+    'save_agent_file',
+    {
+        title: 'Save .agent file',
+        description:
+            'Writes a complete .agent document to disk at an absolute path. USE THIS TOOL to persist edits the user asked for — e.g. "move that card to Done", "add a risk to the log", "rename the project". ' +
+            'The write is atomic (tmp file + rename), validates the full document against the v0.1 schema before writing, and refuses to follow symlinks or overwrite non-regular files. ' +
+            'Typical flow: call render_agent_file to read the current state, compute the next state, call save_agent_file with the full updated document, then call render_agent_file again to show the user the new state. ' +
+            'Pass the ENTIRE document as `data` — this is a full replace, not a patch.',
+        inputSchema: {
+            path: z
+                .string()
+                .describe('Absolute path to the .agent file to write. Must end in `.agent`. If the file exists it will be overwritten; if not, it will be created.'),
+            data: z
+                .unknown()
+                .describe(
+                    'The complete .agent document as a JSON object. Must match the v0.1 schema: { version, name, createdAt, updatedAt, config, sections[], memory }. Partial updates are NOT supported — include every section.',
+                ),
+        },
+    },
+    async ({ path: filePath, data }): Promise<CallToolResult> => {
+        try {
+            // Full schema validation before we touch disk — the file format is
+            // the contract the renderer depends on; malformed writes would
+            // break the round-trip even though they'd land on disk fine.
+            if (!validateAgent(data)) {
+                return invalidAgentResult(validateAgent.errors)
+            }
+            const result = await saveAgentFile(filePath, data)
+            if (!result.ok) {
+                return {
+                    content: [{ type: 'text', text: result.message }],
+                    isError: true,
+                }
+            }
+            return { content: [{ type: 'text', text: result.message }] }
+        } catch (err) {
+            // Log raw to stderr; return a generic message so filesystem
+            // internals (EACCES paths, EXDEV mount points) don't leak.
+            console.error('save_agent_file error:', err)
+            return {
+                content: [{ type: 'text', text: 'Failed to save .agent file.' }],
+                isError: true,
+            }
+        }
+    },
+)
+
+// ─── Skill surface ────────────────────────────────────────────────────────
+// Exposes the authoring guide three ways so every kind of MCP client has a
+// path in: a tool (model-driven, works everywhere), resources (auto-surfaced
+// by clients that read resource lists), and a prompt (user-triggered slash
+// command in Claude Desktop / Cursor). This is the pre-spec "skills over MCP"
+// pattern DSP described at AI Engineer 2026.
+
+server.registerTool(
+    'get_agent_format_skill',
+    {
+        title: 'Get .agent authoring guide',
+        description:
+            'Returns the authoring guide for the .agent file format — the typed JSON artifact this server renders. ' +
+            'Call this BEFORE authoring an .agent document for the first time in a conversation, or whenever the user ' +
+            'asks to visualize / dashboard-ify / structure content (e.g. "turn this into a kanban", "make a timeline"). ' +
+            'Pass `section: "section-types"` for the exact data schema of each section type, or `section: "examples"` ' +
+            'for larger worked examples. Start with `section: "main"`.',
+        inputSchema: {
+            section: z
+                .enum(['main', 'section-types', 'examples'])
+                .optional()
+                .describe('Which part of the guide to return. Defaults to "main".'),
+        },
+    },
+    async ({ section }): Promise<CallToolResult> => {
+        const text = skillText(skill, (section ?? 'main') as SkillSection)
+        return { content: [{ type: 'text', text }] }
+    },
+)
+
+server.registerResource(
+    'agent-format-skill-main',
+    SKILL_URIS.main,
+    {
+        description:
+            'Main authoring guide for the .agent file format. When the user asks to visualize / structure content, ' +
+            'read this to learn when and how to emit .agent documents instead of HTML artifacts.',
+        mimeType: 'text/markdown',
+    },
+    async () => ({
+        contents: [{ uri: SKILL_URIS.main, mimeType: 'text/markdown', text: skill.main }],
+    }),
+)
+
+server.registerResource(
+    'agent-format-skill-section-types',
+    SKILL_URIS['section-types'],
+    {
+        description:
+            'Exact data schema for each .agent section type (kanban, timeline, metrics, log, …). Read this when you need the precise shape of a specific section type.',
+        mimeType: 'text/markdown',
+    },
+    async () => ({
+        contents: [{ uri: SKILL_URIS['section-types'], mimeType: 'text/markdown', text: skill.sectionTypes }],
+    }),
+)
+
+server.registerResource(
+    'agent-format-skill-examples',
+    SKILL_URIS.examples,
+    {
+        description:
+            'Larger worked examples of .agent documents combining multiple section types (project trackers, research logs, OKRs).',
+        mimeType: 'text/markdown',
+    },
+    async () => ({
+        contents: [{ uri: SKILL_URIS.examples, mimeType: 'text/markdown', text: skill.examples }],
+    }),
+)
+
+server.registerPrompt(
+    'agent-format',
+    {
+        title: 'Author .agent file (visualize / dashboard)',
+        description:
+            'Inject the .agent authoring guide so the assistant emits a typed, editable JSON dashboard instead of an HTML artifact.',
+    },
+    () => ({
+        messages: [
+            {
+                role: 'user',
+                content: { type: 'text', text: skill.main },
             },
         ],
     }),

--- a/packages/mcp/src/skill.ts
+++ b/packages/mcp/src/skill.ts
@@ -1,0 +1,43 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+// The authoring skill is vendored into `dist/skill/` at build time (see the
+// `build` script in package.json) from packages/claude-plugin/skills/agent-format/.
+// Single source of truth — if you edit the skill, edit it in claude-plugin and
+// rebuild; don't edit the vendored copy.
+
+export type SkillSection = 'main' | 'section-types' | 'examples'
+
+export interface SkillBundle {
+    main: string
+    sectionTypes: string
+    examples: string
+}
+
+export function loadSkill(skillDir: string): SkillBundle {
+    return {
+        main: fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf8'),
+        sectionTypes: fs.readFileSync(path.join(skillDir, 'references', 'section-types.md'), 'utf8'),
+        examples: fs.readFileSync(path.join(skillDir, 'references', 'examples.md'), 'utf8'),
+    }
+}
+
+export function skillText(bundle: SkillBundle, section: SkillSection): string {
+    switch (section) {
+        case 'section-types':
+            return bundle.sectionTypes
+        case 'examples':
+            return bundle.examples
+        case 'main':
+        default:
+            return bundle.main
+    }
+}
+
+// URI scheme for skill resources. Namespaced under the server so clients can
+// filter / group; the `main` entry is the one to surface first in listings.
+export const SKILL_URIS: Record<SkillSection, string> = {
+    main: 'agent-format://skill/main',
+    'section-types': 'agent-format://skill/section-types',
+    examples: 'agent-format://skill/examples',
+}

--- a/packages/mcp/src/ui-client.tsx
+++ b/packages/mcp/src/ui-client.tsx
@@ -3,7 +3,7 @@
 // because Claude Desktop's sandbox CSP has no frame-src allowance.
 
 import { App } from '@modelcontextprotocol/ext-apps'
-import { StrictMode } from 'react'
+import { StrictMode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import {
     AgentRenderer,
@@ -70,7 +70,175 @@ const hostBridge: HostBridge = {
     },
 }
 
-function render(data: unknown) {
+// Status shown in the floating save indicator.
+type SaveStatus =
+    | { kind: 'idle' }
+    | { kind: 'read-only'; reason: string }
+    | { kind: 'saving' }
+    | { kind: 'saved'; at: number }
+    | { kind: 'error'; message: string }
+
+interface RendererProps {
+    initialData: AgentFile
+    // Absolute path of the .agent file being rendered. Undefined when the
+    // source is render_agent_inline (no file backing) — writeback is disabled
+    // in that case.
+    path: string | undefined
+    // Whether the host advertised serverTools. False → no callServerTool, so
+    // we keep edits in-memory only and surface a read-only banner.
+    serverToolsSupported: boolean
+}
+
+function baselineStatus(
+    path: string | undefined,
+    serverToolsSupported: boolean
+): SaveStatus {
+    if (!path) {
+        return { kind: 'read-only', reason: 'inline data — no file to save to' }
+    }
+    if (!serverToolsSupported) {
+        return { kind: 'read-only', reason: 'host does not support server tool calls' }
+    }
+    return { kind: 'idle' }
+}
+
+function InteractiveRenderer({ initialData, path, serverToolsSupported }: RendererProps) {
+    const [data, setData] = useState<AgentFile>(initialData)
+    const [status, setStatus] = useState<SaveStatus>(() =>
+        baselineStatus(path, serverToolsSupported)
+    )
+
+    // Reset local state when the host pushes a new tool-result (e.g. the
+    // model called render_agent_file after its own save_agent_file). Without
+    // this the iframe would keep showing stale local edits.
+    useEffect(() => {
+        setData(initialData)
+    }, [initialData])
+
+    // Recompute the baseline read-only/idle banner when the writeback path
+    // changes (different file) or capability flips. Otherwise a later
+    // tool-result that should become writable would still show the old
+    // read-only banner, and vice versa.
+    useEffect(() => {
+        setStatus(baselineStatus(path, serverToolsSupported))
+    }, [path, serverToolsSupported])
+
+    const writable = !!path && serverToolsSupported
+    // Monotonic counter so a stale save response can't overwrite a newer one.
+    const saveSeq = useRef(0)
+
+    // KNOWN LIMITATION: two in-flight save_agent_file calls for the same
+    // path can reorder on the server side (no per-path serialization), so
+    // last-rename-wins. The saveSeq guard below only prevents stale
+    // responses from clobbering UI state, not stale payloads from clobbering
+    // disk. Acceptable for single-user Claude Desktop where edits are
+    // human-paced; revisit with an expectedRevision token when/if we see
+    // concurrent writers.
+    const handleChange = useCallback(
+        (next: AgentFile) => {
+            setData(next)
+            if (!writable || !path) return
+            const mySeq = ++saveSeq.current
+            setStatus({ kind: 'saving' })
+            app.callServerTool({
+                name: 'save_agent_file',
+                arguments: { path, data: next },
+            })
+                .then((result) => {
+                    // A later edit already started while this one was in
+                    // flight — let that call's response update the UI instead.
+                    if (mySeq !== saveSeq.current) return
+                    if (result.isError) {
+                        const msg =
+                            result.content?.find((c) => c.type === 'text')?.text ??
+                            'save failed'
+                        setStatus({ kind: 'error', message: msg })
+                    } else {
+                        setStatus({ kind: 'saved', at: Date.now() })
+                    }
+                })
+                .catch((err) => {
+                    if (mySeq !== saveSeq.current) return
+                    setStatus({ kind: 'error', message: String(err) })
+                })
+        },
+        [path, writable]
+    )
+
+    const onChange = writable ? handleChange : undefined
+
+    return useMemo(
+        () => (
+            <>
+                <SaveIndicator status={status} />
+                <AgentRenderer
+                    data={data}
+                    host={hostBridge}
+                    plugins={BUNDLED_PLUGINS}
+                    onChange={onChange}
+                />
+            </>
+        ),
+        [data, onChange, status]
+    )
+}
+
+function SaveIndicator({ status }: { status: SaveStatus }) {
+    // Transient indicators only. `idle` renders nothing to keep the chat
+    // surface quiet when nothing has been edited yet.
+    if (status.kind === 'idle') return null
+
+    const { bg, fg, label } = (() => {
+        switch (status.kind) {
+            case 'read-only':
+                return {
+                    bg: 'rgba(107, 114, 128, 0.12)',
+                    fg: '#6b7280',
+                    label: `Read-only — ${status.reason}`,
+                }
+            case 'saving':
+                return { bg: 'rgba(59, 130, 246, 0.12)', fg: '#3b82f6', label: 'Saving…' }
+            case 'saved':
+                return {
+                    bg: 'rgba(16, 185, 129, 0.12)',
+                    fg: '#10b981',
+                    label: 'Saved',
+                }
+            case 'error':
+                return {
+                    bg: 'rgba(239, 68, 68, 0.15)',
+                    fg: '#ef4444',
+                    label: `Save failed — ${status.message}`,
+                }
+        }
+    })()
+
+    return (
+        <div
+            style={{
+                position: 'sticky',
+                top: 0,
+                zIndex: 10,
+                margin: '0 0 8px',
+                padding: '4px 10px',
+                fontSize: 12,
+                fontFamily: '-apple-system, system-ui, "Segoe UI", sans-serif',
+                background: bg,
+                color: fg,
+                borderRadius: 4,
+                display: 'inline-block',
+            }}
+        >
+            {label}
+        </div>
+    )
+}
+
+function render(
+    data: unknown,
+    path: string | undefined,
+    serverToolsSupported: boolean
+) {
     if (
         !data ||
         typeof data !== 'object' ||
@@ -87,10 +255,10 @@ function render(data: unknown) {
 
         ensureRoot().render(
             <StrictMode>
-                <AgentRenderer
-                    data={data as AgentFile}
-                    host={hostBridge}
-                    plugins={BUNDLED_PLUGINS}
+                <InteractiveRenderer
+                    initialData={data as AgentFile}
+                    path={path}
+                    serverToolsSupported={serverToolsSupported}
                 />
             </StrictMode>
         )
@@ -100,10 +268,17 @@ function render(data: unknown) {
 }
 
 // Must be set BEFORE connect() so the initial tool-result isn't missed.
+// structuredContent now also carries the absolute path (from render_agent_file)
+// — undefined when the source was render_agent_inline.
 app.ontoolresult = (result: {
-    structuredContent?: { data?: unknown }
+    structuredContent?: { data?: unknown; path?: unknown }
 }) => {
-    render(result?.structuredContent?.data)
+    const sc = result?.structuredContent
+    const pathValue = typeof sc?.path === 'string' ? sc.path : undefined
+    // Capability is only known after connect() resolves. Re-read it on every
+    // tool-result so we pick up late-initialized host info.
+    const serverToolsSupported = !!app.getHostCapabilities()?.serverTools
+    render(sc?.data, pathValue, serverToolsSupported)
 }
 
 app.connect()

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import { resolveAgentFile } from '../src/resolve'
+import { resolveAgentFile, saveAgentFile } from '../src/resolve'
 
 const VALID_AGENT = {
     version: '0.1',
@@ -114,5 +114,105 @@ describe('resolveAgentFile', () => {
         const r = await resolveAgentFile(p)
         expect(r.ok).toBe(false)
         expect(r.message).toContain('not a valid .agent')
+    })
+})
+
+describe('saveAgentFile', () => {
+    let tmp: string
+
+    beforeEach(async () => {
+        tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'af-mcp-save-'))
+    })
+    afterEach(async () => {
+        await fs.rm(tmp, { recursive: true, force: true })
+    })
+
+    it('creates a new .agent file when none exists', async () => {
+        const p = path.join(tmp, 'new.agent')
+        const r = await saveAgentFile(p, VALID_AGENT)
+        expect(r.ok).toBe(true)
+        expect(r.bytesWritten).toBeGreaterThan(0)
+        const roundtrip = JSON.parse(await fs.readFile(p, 'utf8'))
+        expect(roundtrip.sections).toEqual([])
+    })
+
+    it('overwrites an existing .agent file atomically', async () => {
+        const p = path.join(tmp, 'existing.agent')
+        await fs.writeFile(p, JSON.stringify({ old: true }))
+        const r = await saveAgentFile(p, VALID_AGENT)
+        expect(r.ok).toBe(true)
+        const roundtrip = JSON.parse(await fs.readFile(p, 'utf8'))
+        expect(roundtrip.name).toBe('t')
+    })
+
+    it('leaves no leftover .tmp-* sibling files after a successful write', async () => {
+        const p = path.join(tmp, 'clean.agent')
+        await saveAgentFile(p, VALID_AGENT)
+        const entries = await fs.readdir(tmp)
+        expect(entries.filter((e) => e.includes('.tmp-'))).toEqual([])
+    })
+
+    it('rejects relative paths before touching the filesystem', async () => {
+        const r = await saveAgentFile('relative.agent', VALID_AGENT)
+        expect(r.ok).toBe(false)
+        expect(r.message).toBe('filePath must be an absolute path')
+    })
+
+    it('rejects a non-.agent extension', async () => {
+        const p = path.join(tmp, 'x.json')
+        const r = await saveAgentFile(p, VALID_AGENT)
+        expect(r.ok).toBe(false)
+        expect(r.message).toContain('.agent extension')
+    })
+
+    it('refuses to overwrite a symlink', async () => {
+        const target = path.join(tmp, 'target')
+        await fs.writeFile(target, 'original')
+        const link = path.join(tmp, 'link.agent')
+        await fs.symlink(target, link)
+        const r = await saveAgentFile(link, VALID_AGENT)
+        expect(r.ok).toBe(false)
+        expect(r.message.toLowerCase()).toContain('symlink')
+        // Target must be untouched — this is the exfil-prevention claim.
+        expect(await fs.readFile(target, 'utf8')).toBe('original')
+    })
+
+    it('refuses to overwrite a directory', async () => {
+        const p = path.join(tmp, 'dir.agent')
+        await fs.mkdir(p)
+        const r = await saveAgentFile(p, VALID_AGENT)
+        expect(r.ok).toBe(false)
+        expect(r.message).toContain('not a regular file')
+    })
+
+    it('rejects data that is not shape-like (no sections array)', async () => {
+        const p = path.join(tmp, 'bad.agent')
+        const r = await saveAgentFile(p, { version: '0.1' })
+        expect(r.ok).toBe(false)
+        expect(r.message).toContain('not a valid .agent')
+        // Must not have created a file when the shape check failed.
+        await expect(fs.stat(p)).rejects.toThrow()
+    })
+
+    it('rejects payloads larger than MAX_AGENT_FILE_BYTES', async () => {
+        const p = path.join(tmp, 'big.agent')
+        // Build a .agent document whose serialized form exceeds 5 MB by
+        // packing a giant string into `description`.
+        const big = {
+            ...VALID_AGENT,
+            description: 'x'.repeat(5 * 1024 * 1024 + 10),
+        }
+        const r = await saveAgentFile(p, big)
+        expect(r.ok).toBe(false)
+        expect(r.message).toContain('limit')
+        await expect(fs.stat(p)).rejects.toThrow()
+    })
+
+    it('pretty-prints with 2-space indent and trailing newline', async () => {
+        const p = path.join(tmp, 'pretty.agent')
+        await saveAgentFile(p, VALID_AGENT)
+        const text = await fs.readFile(p, 'utf8')
+        expect(text.endsWith('\n')).toBe(true)
+        expect(text).toContain('\n  "version"')
     })
 })

--- a/packages/mcp/tests/skill.test.ts
+++ b/packages/mcp/tests/skill.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { loadSkill, SKILL_URIS, skillText } from '../src/skill'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+// Tests read the source-of-truth skill dir (packages/claude-plugin/skills/...)
+// rather than the build artifact, so they pass before `npm run build`.
+const SKILL_DIR = path.resolve(__dirname, '..', '..', 'claude-plugin', 'skills', 'agent-format')
+
+describe('loadSkill', () => {
+    const bundle = loadSkill(SKILL_DIR)
+
+    it('loads all three skill files with non-empty content', () => {
+        expect(bundle.main.length).toBeGreaterThan(0)
+        expect(bundle.sectionTypes.length).toBeGreaterThan(0)
+        expect(bundle.examples.length).toBeGreaterThan(0)
+    })
+
+    it('main guide leads with frontmatter and the skill body', () => {
+        expect(bundle.main.startsWith('---')).toBe(true)
+        expect(bundle.main).toContain('agent-format-visualize')
+    })
+
+    it('skillText routes each section to the right file', () => {
+        expect(skillText(bundle, 'main')).toBe(bundle.main)
+        expect(skillText(bundle, 'section-types')).toBe(bundle.sectionTypes)
+        expect(skillText(bundle, 'examples')).toBe(bundle.examples)
+    })
+
+    it('SKILL_URIS are namespaced and stable', () => {
+        expect(SKILL_URIS.main).toBe('agent-format://skill/main')
+        expect(SKILL_URIS['section-types']).toBe('agent-format://skill/section-types')
+        expect(SKILL_URIS.examples).toBe('agent-format://skill/examples')
+    })
+})

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-format/renderer",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "React renderer for the agent file format (.agent).",
   "license": "MIT",
   "author": "Yuya Morita",

--- a/packages/renderer/src/index.tsx
+++ b/packages/renderer/src/index.tsx
@@ -29,6 +29,7 @@ export {
     downloadPrintableHtml,
 } from './actions'
 export { sanitizeSvgForEmbed } from './sanitize'
+export { validateSemantics, type SemanticError } from './validate'
 
 // Spec major version this renderer is built against. Documents whose
 // `version` major exceeds this are rendered with a warning banner; the

--- a/packages/renderer/src/index.tsx
+++ b/packages/renderer/src/index.tsx
@@ -72,6 +72,12 @@ interface AgentRendererProps {
      */
     host?: HostBridge
     /**
+     * Controls visibility of the document title/description header.
+     * Default: true. Set to false when the host already renders its own
+     * top-level file chrome and repeating the document title wastes space.
+     */
+    showDocumentHeader?: boolean
+    /**
      * Controls visibility of the header "Open in browser" action.
      * Default: true. Set to false when the renderer is already used inside
      * the public viewer itself (avoids a self-referential button).
@@ -111,6 +117,7 @@ export function AgentRenderer({
     data,
     className,
     host,
+    showDocumentHeader = true,
     showOpenInViewer = true,
     plugins = [],
     onChange,
@@ -159,35 +166,37 @@ export function AgentRenderer({
                             best-effort fallbacks — unknown fields may be ignored.
                         </div>
                     )}
-                    <header className="af-header">
-                        <div className="af-header-main">
-                            <h1 className="af-title">
-                                {data.icon && <span>{data.icon}</span>}
-                                <span>{data.name}</span>
-                            </h1>
-                            {data.description && (
-                                <p className="af-description">{data.description}</p>
-                            )}
-                        </div>
-                        {showOpenInViewer && (
-                            <div className="af-header-actions">
-                                <button
-                                    type="button"
-                                    className="af-action-btn"
-                                    onClick={() => {
-                                        // Fire-and-forget; ignore host denial —
-                                        // user will notice if the page didn't
-                                        // open and can retry.
-                                        void openInViewer(data, host)
-                                    }}
-                                    title="Open this file in the public agent-format viewer (new tab)"
-                                >
-                                    <span aria-hidden>↗</span>
-                                    <span>Open in browser</span>
-                                </button>
+                    {showDocumentHeader && (
+                        <header className="af-header">
+                            <div className="af-header-main">
+                                <h1 className="af-title">
+                                    {data.icon && <span>{data.icon}</span>}
+                                    <span>{data.name}</span>
+                                </h1>
+                                {data.description && (
+                                    <p className="af-description">{data.description}</p>
+                                )}
                             </div>
-                        )}
-                    </header>
+                            {showOpenInViewer && (
+                                <div className="af-header-actions">
+                                    <button
+                                        type="button"
+                                        className="af-action-btn"
+                                        onClick={() => {
+                                            // Fire-and-forget; ignore host denial —
+                                            // user will notice if the page didn't
+                                            // open and can retry.
+                                            void openInViewer(data, host)
+                                        }}
+                                        title="Open this file in the public agent-format viewer (new tab)"
+                                    >
+                                        <span aria-hidden>↗</span>
+                                        <span>Open in browser</span>
+                                    </button>
+                                </div>
+                            )}
+                        </header>
+                    )}
                     <div className="af-sections">
                         {sections.map((section) => (
                             <SectionFrame key={section.id} section={section} />

--- a/packages/renderer/src/index.tsx
+++ b/packages/renderer/src/index.tsx
@@ -83,6 +83,28 @@ interface AgentRendererProps {
      * Earlier plugins win on conflicting `(sectionType, variant)` pairs.
      */
     plugins?: ReadonlyArray<RendererPlugin>
+    /**
+     * If provided, the renderer becomes editable: section views that support
+     * edits (starting with kanban) surface drag-and-drop and inline-edit
+     * affordances, and call this with the next document state on every edit.
+     * When omitted, the renderer stays read-only — existing callers keep
+     * their current behavior unchanged.
+     */
+    onChange?: (next: AgentFile) => void
+}
+
+const SectionChangeContext = createContext<((next: Section) => void) | undefined>(
+    undefined
+)
+
+/**
+ * A section view that supports edits consumes this to receive a typed
+ * change callback: `const onChange = useSectionChange<KanbanSection>()`.
+ * Returns `undefined` in read-only mode.
+ */
+export function useSectionChange<S extends Section>(): ((next: S) => void) | undefined {
+    const cb = useContext(SectionChangeContext)
+    return cb as ((next: S) => void) | undefined
 }
 
 export function AgentRenderer({
@@ -91,13 +113,31 @@ export function AgentRenderer({
     host,
     showOpenInViewer = true,
     plugins = [],
+    onChange,
 }: AgentRendererProps) {
     const sections = [...data.sections].sort((a, b) => a.order - b.order)
     const docMajor = parseVersionMajor(data.version)
     const unsupportedMajor = docMajor !== null && docMajor > SPEC_MAJOR
 
+    // Fold a typed section edit into the full AgentFile and bump updatedAt
+    // so downstream writers (save_agent_file, git diffs) see the change.
+    // Memoized so context consumers don't re-run unnecessarily.
+    const handleSectionChange = onChange
+        ? (nextSection: Section): void => {
+              const nextSections = data.sections.map((s) =>
+                  s.id === nextSection.id ? nextSection : s
+              )
+              onChange({
+                  ...data,
+                  sections: nextSections,
+                  updatedAt: new Date().toISOString(),
+              })
+          }
+        : undefined
+
     return (
         <HostContext.Provider value={host}>
+            <SectionChangeContext.Provider value={handleSectionChange}>
             <PluginsContext.Provider value={plugins}>
                 <div className={`af-root ${className ?? ''}`}>
                     {unsupportedMajor && (
@@ -155,6 +195,7 @@ export function AgentRenderer({
                     </div>
                 </div>
             </PluginsContext.Provider>
+            </SectionChangeContext.Provider>
         </HostContext.Provider>
     )
 }

--- a/packages/renderer/src/sanitize.ts
+++ b/packages/renderer/src/sanitize.ts
@@ -144,20 +144,38 @@ function sanitizeDom(root: Element): void {
     for (const el of toRemove) el.parentNode?.removeChild(el)
 }
 
-// Hardened regex fallback for environments without DOMParser. Intentionally
-// aggressive: we'd rather destroy valid SVG than miss a payload.
+// Allowlist-based regex fallback for environments without DOMParser.
+// Intentionally aggressive: we'd rather destroy valid SVG than miss a payload.
+//
+// Two-stage model:
+//   1. Content-destroying pass for tags whose *contents* are dangerous
+//      (script, style, foreignObject, …). These get their open+close tags
+//      and the text between them deleted wholesale.
+//   2. Allowlist pass: every tag marker (`<x>`, `</x>`, `<x/>`) whose
+//      localName is not in ALLOWED_TAGS has its markers stripped. Text
+//      nodes between unknown tags are preserved but become plain content
+//      once the element boundary is gone, which is what makes this an
+//      allowlist rather than an ever-growing blocklist.
+const ALLOWED_TAGS_LC = new Set(
+    Array.from(ALLOWED_TAGS, (t) => t.toLowerCase())
+)
+
 function sanitizeRegex(svg: string): string {
     let out = svg
-    // Strip anything that looks like a script / style / foreign-object block,
-    // with or without namespace prefixes (handles `<svg:script>`).
-    const blockTags = [
+    // Stage 1: destroy tag-and-content for the highest-risk elements.
+    // These carry payloads in their child text/CDATA (script bodies,
+    // CSS expressions, HTML-in-SVG), so we can't just strip the markers.
+    // SMIL animation elements get destroyed here too because `<animate
+    // to="javascript:…">` can hijack a permitted href at runtime.
+    const destroyTags = [
         'script', 'style', 'foreignObject', 'iframe', 'object', 'embed',
-        // SMIL animation elements can hijack permitted href/src attributes
-        // via `to=`/`values=`/`from=` even if their own attributes look clean.
         'animate', 'animateTransform', 'animateMotion', 'set', 'mpath', 'discard',
         'audio', 'video', 'canvas',
+        // SVG `<image>` element loads external images. Not in ALLOWED_TAGS,
+        // but listed here so the content is destroyed, not just the markers.
+        'image',
     ]
-    for (const t of blockTags) {
+    for (const t of destroyTags) {
         const open = new RegExp(`<(?:[\\w-]+:)?${t}\\b[^>]*>[\\s\\S]*?<\\/(?:[\\w-]+:)?${t}\\s*[^>]*>`, 'gi')
         const selfClose = new RegExp(`<(?:[\\w-]+:)?${t}\\b[^>]*\\/>`, 'gi')
         // Also strip malformed / unterminated openings up to the next `>`
@@ -165,6 +183,19 @@ function sanitizeRegex(svg: string): string {
         const orphan = new RegExp(`<(?:[\\w-]+:)?${t}\\b[^>]*>`, 'gi')
         out = out.replace(open, '').replace(selfClose, '').replace(orphan, '')
     }
+    // Stage 2: allowlist pass. Any tag whose localName isn't in
+    // ALLOWED_TAGS has its `<...>` markers deleted. Attribute values that
+    // happen to contain `>` will cause boundary confusion and over-strip
+    // — that's intentionally false-positive. Comments and CDATA are
+    // stripped unconditionally to avoid tag-smuggling tricks.
+    out = out.replace(/<!--[\s\S]*?-->/g, '')
+    out = out.replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '')
+    out = out.replace(
+        /<\/?(?:[\w-]+:)?([\w-]+)\b[^>]*?\/?>/g,
+        (match, localName: string) => {
+            return ALLOWED_TAGS_LC.has(String(localName).toLowerCase()) ? match : ''
+        }
+    )
     // Drop all on* attributes.
     out = out.replace(/\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '')
     // Drop all style="" attributes.

--- a/packages/renderer/src/sections/KanbanSection.tsx
+++ b/packages/renderer/src/sections/KanbanSection.tsx
@@ -1,4 +1,7 @@
+import { useState } from 'react'
+import type { DragEvent, KeyboardEvent } from 'react'
 import type { KanbanSection } from '../types'
+import { useSectionChange } from '../index'
 
 interface Props {
     section: KanbanSection
@@ -23,7 +26,26 @@ function safeColor(c: string | undefined): string | undefined {
     return COLOR_RE.test(trimmed) ? trimmed : undefined
 }
 
+// DataTransfer type used for card DnD — namespaced so dropping some other
+// draggable (a browser tab URL, a file) onto a column doesn't race with a
+// real card drop. We mirror the item id into text/plain as a real fallback
+// for hosts that strip custom MIME types (some Safari/WebView configs); the
+// drop handler accepts either channel and ignores payloads that don't match
+// any known item id, which also rejects spurious drops (URLs, file paths).
+const DT_TYPE = 'application/x-agent-format-kanban-item'
+
 export function KanbanSectionView({ section }: Props) {
+    const onChange = useSectionChange<KanbanSection>()
+    const editable = !!onChange
+
+    // itemId of the card currently being dragged, so drop targets can render
+    // a hover affordance without relying on browser-drag-source state (Safari
+    // is inconsistent there). null when nothing is dragging.
+    const [draggingId, setDraggingId] = useState<string | null>(null)
+    // itemId of the title currently being edited inline, or null. One at a
+    // time — entering edit on a second card commits the first.
+    const [editingId, setEditingId] = useState<string | null>(null)
+
     const columns = section.data?.columns ?? []
     const items = section.data?.items ?? []
     const labels = section.data?.labels ?? []
@@ -39,12 +61,85 @@ export function KanbanSectionView({ section }: Props) {
         if (list) list.push(item)
     }
 
+    // Move an item to a different column. No-op if the item is already there
+    // so drops onto the same column don't churn updatedAt unnecessarily.
+    function moveItem(itemId: string, toColumnId: string): void {
+        if (!onChange) return
+        const item = items.find((i) => i.id === itemId)
+        if (!item || item.status === toColumnId) return
+        const now = new Date().toISOString()
+        const nextItems = items.map((i) =>
+            i.id === itemId ? { ...i, status: toColumnId, updatedAt: now } : i
+        )
+        onChange({
+            ...section,
+            data: { ...section.data, items: nextItems },
+        })
+    }
+
+    function renameItem(itemId: string, nextTitle: string): void {
+        if (!onChange) return
+        const trimmed = nextTitle.trim()
+        const item = items.find((i) => i.id === itemId)
+        if (!item || trimmed === '' || trimmed === item.title) return
+        const now = new Date().toISOString()
+        const nextItems = items.map((i) =>
+            i.id === itemId ? { ...i, title: trimmed, updatedAt: now } : i
+        )
+        onChange({
+            ...section,
+            data: { ...section.data, items: nextItems },
+        })
+    }
+
     return (
         <div className="af-kanban">
             {sortedColumns.map((col) => {
                 const colItems = itemsByColumn.get(col.id) ?? []
+                const isDropTarget =
+                    editable && draggingId !== null
+                        ? items.find((i) => i.id === draggingId)?.status !== col.id
+                        : false
                 return (
-                    <div key={col.id} className="af-column">
+                    <div
+                        key={col.id}
+                        className={`af-column${isDropTarget ? ' af-column--drop-target' : ''}`}
+                        onDragOver={
+                            editable
+                                ? (e: DragEvent<HTMLDivElement>) => {
+                                      // Accept drops that carry our namespaced type OR a
+                                      // plain-text payload (our text/plain fallback for
+                                      // hosts that strip custom MIME). Must preventDefault
+                                      // or the drop event never fires.
+                                      if (
+                                          e.dataTransfer.types.includes(DT_TYPE) ||
+                                          e.dataTransfer.types.includes('text/plain')
+                                      ) {
+                                          e.preventDefault()
+                                          e.dataTransfer.dropEffect = 'move'
+                                      }
+                                  }
+                                : undefined
+                        }
+                        onDrop={
+                            editable
+                                ? (e: DragEvent<HTMLDivElement>) => {
+                                      // Prefer the namespaced type; fall back to text/plain
+                                      // and validate that the payload matches a known item
+                                      // id so foreign drops (URLs, filenames) no-op instead
+                                      // of moving a random card.
+                                      const raw =
+                                          e.dataTransfer.getData(DT_TYPE) ||
+                                          e.dataTransfer.getData('text/plain')
+                                      if (raw && items.some((i) => i.id === raw)) {
+                                          e.preventDefault()
+                                          moveItem(raw, col.id)
+                                      }
+                                      setDraggingId(null)
+                                  }
+                                : undefined
+                        }
+                    >
                         <div className="af-column-title">
                             <span>{col.name}</span>
                             <span>
@@ -52,40 +147,118 @@ export function KanbanSectionView({ section }: Props) {
                                 {col.wipLimit ? ` / ${col.wipLimit}` : ''}
                             </span>
                         </div>
-                        {colItems.map((item) => (
-                            <div key={item.id} className="af-card">
-                                <p className="af-card-title">{item.title}</p>
-                                {item.description && <p className="af-card-desc">{item.description}</p>}
-                                {item.labelIds.length > 0 && (
-                                    <div className="af-card-labels">
-                                        {item.labelIds.map((lid) => {
-                                            const label = labelById.get(lid)
-                                            if (!label) return null
-                                            const bg = safeColor(label.color)
-                                            return (
-                                                <span
-                                                    key={lid}
-                                                    className="af-label"
-                                                    style={bg ? { background: bg } : undefined}
-                                                >
-                                                    {label.name}
-                                                </span>
-                                            )
-                                        })}
-                                    </div>
-                                )}
-                                {(item.assignee || item.dueDate || item.priority) && (
-                                    <div className="af-card-meta">
-                                        {item.priority && <span>• {item.priority}</span>}
-                                        {item.assignee && <span>@ {item.assignee}</span>}
-                                        {item.dueDate && <span>⏰ {item.dueDate}</span>}
-                                    </div>
-                                )}
-                            </div>
-                        ))}
+                        {colItems.map((item) => {
+                            const isDragging = editable && draggingId === item.id
+                            const isEditing = editable && editingId === item.id
+                            return (
+                                <div
+                                    key={item.id}
+                                    className={`af-card${isDragging ? ' af-card--dragging' : ''}`}
+                                    draggable={editable && !isEditing}
+                                    onDragStart={
+                                        editable
+                                            ? (e: DragEvent<HTMLDivElement>) => {
+                                                  e.dataTransfer.effectAllowed = 'move'
+                                                  e.dataTransfer.setData(DT_TYPE, item.id)
+                                                  // Mirror id into text/plain so hosts that
+                                                  // drop custom MIME types still get a
+                                                  // working payload at drop time.
+                                                  e.dataTransfer.setData('text/plain', item.id)
+                                                  setDraggingId(item.id)
+                                              }
+                                            : undefined
+                                    }
+                                    onDragEnd={editable ? () => setDraggingId(null) : undefined}
+                                >
+                                    {isEditing ? (
+                                        <TitleEditor
+                                            initial={item.title}
+                                            onCommit={(next) => {
+                                                renameItem(item.id, next)
+                                                setEditingId(null)
+                                            }}
+                                            onCancel={() => setEditingId(null)}
+                                        />
+                                    ) : (
+                                        <p
+                                            className={`af-card-title${editable ? ' af-card-title--editable' : ''}`}
+                                            // Double-click to enter edit, so a single-click
+                                            // drag never triggers accidental edit mode. Title
+                                            // is the only editable field in v1; description /
+                                            // labels / priority come later.
+                                            onDoubleClick={
+                                                editable
+                                                    ? () => setEditingId(item.id)
+                                                    : undefined
+                                            }
+                                            title={editable ? 'Double-click to edit' : undefined}
+                                        >
+                                            {item.title}
+                                        </p>
+                                    )}
+                                    {item.description && <p className="af-card-desc">{item.description}</p>}
+                                    {item.labelIds.length > 0 && (
+                                        <div className="af-card-labels">
+                                            {item.labelIds.map((lid) => {
+                                                const label = labelById.get(lid)
+                                                if (!label) return null
+                                                const bg = safeColor(label.color)
+                                                return (
+                                                    <span
+                                                        key={lid}
+                                                        className="af-label"
+                                                        style={bg ? { background: bg } : undefined}
+                                                    >
+                                                        {label.name}
+                                                    </span>
+                                                )
+                                            })}
+                                        </div>
+                                    )}
+                                    {(item.assignee || item.dueDate || item.priority) && (
+                                        <div className="af-card-meta">
+                                            {item.priority && <span>• {item.priority}</span>}
+                                            {item.assignee && <span>@ {item.assignee}</span>}
+                                            {item.dueDate && <span>⏰ {item.dueDate}</span>}
+                                        </div>
+                                    )}
+                                </div>
+                            )
+                        })}
                     </div>
                 )
             })}
         </div>
+    )
+}
+
+function TitleEditor({
+    initial,
+    onCommit,
+    onCancel,
+}: {
+    initial: string
+    onCommit: (next: string) => void
+    onCancel: () => void
+}) {
+    const [value, setValue] = useState(initial)
+    return (
+        <input
+            className="af-card-title-input"
+            type="text"
+            value={value}
+            autoFocus
+            onChange={(e) => setValue(e.target.value)}
+            onBlur={() => onCommit(value)}
+            onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault()
+                    onCommit(value)
+                } else if (e.key === 'Escape') {
+                    e.preventDefault()
+                    onCancel()
+                }
+            }}
+        />
     )
 }

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -184,9 +184,35 @@
     cursor: grab;
 }
 
+.af-card--dragging {
+    opacity: 0.4;
+}
+
+.af-column--drop-target {
+    outline: 2px dashed var(--af-accent, #3b82f6);
+    outline-offset: -2px;
+}
+
 .af-card-title {
     font-weight: 600;
     margin: 0 0 4px;
+}
+
+.af-card-title--editable {
+    cursor: text;
+}
+
+.af-card-title-input {
+    font: inherit;
+    font-weight: 600;
+    width: 100%;
+    margin: 0 0 4px;
+    padding: 2px 4px;
+    border: 1px solid var(--af-accent, #3b82f6);
+    border-radius: 3px;
+    background: var(--af-bg);
+    color: inherit;
+    box-sizing: border-box;
 }
 
 .af-card-desc {

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -813,3 +813,186 @@
         fill: #000;
     }
 }
+
+.af-jp-court-stage {
+    position: relative;
+}
+
+.af-jp-court-editor-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.af-jp-court-node-hitbox {
+    position: absolute;
+    pointer-events: auto;
+    border: 1px dashed transparent;
+    border-radius: 10px;
+    background: transparent;
+    cursor: pointer;
+}
+
+.af-jp-court-node-hitbox:hover,
+.af-jp-court-node-hitbox:focus-visible {
+    border-color: rgba(34, 81, 255, 0.5);
+    background: rgba(34, 81, 255, 0.06);
+    outline: none;
+}
+
+.af-jp-court-node-hitbox.is-selected {
+    border-color: rgba(34, 81, 255, 0.85);
+    background: rgba(34, 81, 255, 0.1);
+    box-shadow: 0 0 0 2px rgba(34, 81, 255, 0.12);
+}
+
+.af-jp-court-editor-panel {
+    margin-top: 16px;
+    padding: 18px;
+    border: 1px solid rgba(93, 128, 255, 0.28);
+    border-radius: 16px;
+    background:
+        linear-gradient(180deg, rgba(23, 26, 34, 0.97), rgba(15, 17, 24, 0.97));
+    color: #eef2ff;
+    box-shadow:
+        0 20px 50px rgba(15, 17, 24, 0.28),
+        0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+}
+
+.af-jp-court-editor-panel--popover {
+    position: absolute;
+    z-index: 4;
+    margin-top: 0;
+    overflow: auto;
+    backdrop-filter: blur(12px);
+}
+
+.af-jp-court-editor-toolbar {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+    margin-bottom: 16px;
+    padding-bottom: 14px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.af-jp-court-editor-toolbar .af-action-btn {
+    background: rgba(255, 255, 255, 0.06);
+    color: #f8fafc;
+    border-color: rgba(148, 163, 184, 0.22);
+}
+
+.af-jp-court-editor-toolbar .af-action-btn:hover {
+    background: rgba(93, 128, 255, 0.16);
+    border-color: rgba(93, 128, 255, 0.38);
+}
+
+.af-jp-court-editor-toolbar .af-action-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.af-jp-court-editor-note {
+    margin: 0 0 14px;
+    color: rgba(226, 232, 240, 0.74);
+    font-size: 12px;
+    line-height: 1.55;
+}
+
+.af-jp-court-editor-selected {
+    margin: 0 0 16px;
+    font-size: 13px;
+    color: rgba(241, 245, 249, 0.96);
+}
+
+.af-jp-court-editor-selected strong {
+    color: #ffffff;
+}
+
+.af-jp-court-editor-empty {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.74);
+    font-size: 13px;
+}
+
+.af-jp-court-editor-grid {
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.af-jp-court-editor-field {
+    display: grid;
+    gap: 7px;
+}
+
+.af-jp-court-editor-field--full {
+    grid-column: 1 / -1;
+}
+
+.af-jp-court-editor-field label {
+    font-size: 12px;
+    font-weight: 600;
+    color: rgba(226, 232, 240, 0.84);
+    letter-spacing: 0.01em;
+}
+
+.af-jp-court-editor-checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    user-select: none;
+    padding: 2px 0;
+}
+
+.af-jp-court-editor-checkbox input {
+    width: 16px;
+    height: 16px;
+    accent-color: #5d80ff;
+    flex: 0 0 auto;
+}
+
+.af-jp-court-editor-checkbox span {
+    font-size: 13px;
+    color: rgba(241, 245, 249, 0.92);
+    line-height: 1.4;
+}
+
+.af-jp-court-editor-field input[type='text'] {
+    width: 100%;
+    min-width: 0;
+    padding: 10px 12px;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 10px;
+    background: rgba(2, 6, 23, 0.62);
+    color: #f8fafc;
+    font: inherit;
+    box-sizing: border-box;
+    transition: border-color 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+.af-jp-court-editor-field input::placeholder {
+    color: rgba(148, 163, 184, 0.7);
+}
+
+.af-jp-court-editor-field input[type='text']:focus {
+    outline: none;
+    border-color: rgba(93, 128, 255, 0.72);
+    background: rgba(2, 6, 23, 0.82);
+    box-shadow: 0 0 0 3px rgba(93, 128, 255, 0.18);
+}
+
+@media (max-width: 900px) {
+    .af-jp-court-editor-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+@media print {
+    .af-jp-court-editor-layer,
+    .af-jp-court-editor-panel {
+        display: none !important;
+    }
+}

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -293,6 +293,7 @@ export interface FamilyGraphPerson {
     role?: string // free text, renderer-dependent (e.g. 被相続人 / grandparent / 代襲相続人)
     birthday?: string // free text (any calendar / format)
     address?: string
+    isLastAddress?: boolean
     deathDate?: string
     aliases?: string[]
 }

--- a/packages/renderer/src/validate.ts
+++ b/packages/renderer/src/validate.ts
@@ -1,0 +1,437 @@
+// Semantic validation — the checks the JSON Schema cannot express.
+//
+// The schema in `schemas/agent.schema.json` is structural: it enforces shape
+// and required fields. It cannot enforce that IDs are unique within a parent
+// collection, that a kanban item's `status` points at a real column, or that
+// a table cell for a `status` column has the `{ state, comment? }` object
+// shape. Those checks live here. Call `validateSemantics` after the schema
+// validation passes so reports surface one layer at a time.
+//
+// This module is pure TS with no deps so both the CLI and, in future, other
+// validators can lift it verbatim.
+
+export interface SemanticError {
+    instancePath: string
+    message: string
+}
+
+type AnyObj = Record<string, unknown>
+
+function isObj(x: unknown): x is AnyObj {
+    return typeof x === 'object' && x !== null && !Array.isArray(x)
+}
+
+// Collect duplicate IDs across an array of { id: string } objects and emit
+// one error per duplicate group (not per collision) so the CLI output stays
+// readable on large boards.
+// instancePath values emitted here follow RFC 6901 JSON Pointer — the same
+// format Ajv uses — so CLI stderr and the viewer's error list can be filtered
+// with `jq`/awk uniformly regardless of which stage raised the error.
+function checkUniqueIds(
+    items: unknown,
+    basePath: string,
+    errors: SemanticError[]
+): void {
+    if (!Array.isArray(items)) return
+    const seen = new Map<string, number[]>()
+    items.forEach((item, idx) => {
+        if (!isObj(item)) return
+        const id = item.id
+        if (typeof id !== 'string') return
+        const hits = seen.get(id)
+        if (hits) hits.push(idx)
+        else seen.set(id, [idx])
+    })
+    for (const [id, hits] of seen) {
+        if (hits.length > 1) {
+            errors.push({
+                instancePath: `${basePath}/${hits[0]}`,
+                message: `duplicate id "${id}" in ${basePath} (also at ${hits
+                    .slice(1)
+                    .map((i) => `${basePath}/${i}`)
+                    .join(', ')})`,
+            })
+        }
+    }
+}
+
+function validateKanban(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    const columns = Array.isArray(data.columns) ? data.columns : []
+    const items = Array.isArray(data.items) ? data.items : []
+    const labels = Array.isArray(data.labels) ? data.labels : []
+    const team = Array.isArray(data.team) ? data.team : []
+
+    const sec = `/sections/${secIdx}/data`
+    checkUniqueIds(columns, `${sec}/columns`, errors)
+    checkUniqueIds(items, `${sec}/items`, errors)
+    checkUniqueIds(labels, `${sec}/labels`, errors)
+    checkUniqueIds(team, `${sec}/team`, errors)
+
+    const colIds = new Set(
+        columns
+            .filter(isObj)
+            .map((c) => c.id)
+            .filter((v): v is string => typeof v === 'string')
+    )
+    const labelIds = new Set(
+        labels
+            .filter(isObj)
+            .map((l) => l.id)
+            .filter((v): v is string => typeof v === 'string')
+    )
+    const itemIds = new Set(
+        items
+            .filter(isObj)
+            .map((i) => i.id)
+            .filter((v): v is string => typeof v === 'string')
+    )
+
+    items.forEach((it, idx) => {
+        if (!isObj(it)) return
+        const path = `${sec}/items/${idx}`
+        if (typeof it.status === 'string' && !colIds.has(it.status)) {
+            errors.push({
+                instancePath: `${path}/status`,
+                message: `status "${it.status}" is not a known column id`,
+            })
+        }
+        if (Array.isArray(it.labelIds)) {
+            it.labelIds.forEach((lid, li) => {
+                if (typeof lid === 'string' && !labelIds.has(lid)) {
+                    errors.push({
+                        instancePath: `${path}/labelIds/${li}`,
+                        message: `labelId "${lid}" is not defined in labels`,
+                    })
+                }
+            })
+        }
+        if (Array.isArray(it.blockedBy)) {
+            it.blockedBy.forEach((bid, bi) => {
+                if (typeof bid === 'string' && !itemIds.has(bid)) {
+                    errors.push({
+                        instancePath: `${path}/blockedBy/${bi}`,
+                        message: `blockedBy "${bid}" is not a known item id`,
+                    })
+                }
+            })
+        }
+    })
+}
+
+const TABLE_STATUS_STATES = new Set(['todo', 'inprogress', 'almost', 'done', 'warn'])
+
+function validateTable(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    const columns = Array.isArray(data.columns) ? data.columns : []
+    const rows = Array.isArray(data.rows) ? data.rows : []
+    const sec = `/sections/${secIdx}/data`
+
+    // Table column keys must be unique — two `"priority"` columns in the
+    // same table is ambiguous. Schema doesn't enforce this because it
+    // treats columns as an array of independent objects.
+    const keys = columns
+        .filter(isObj)
+        .map((c) => c.key)
+        .filter((v): v is string => typeof v === 'string')
+    const dupKeys = keys.filter((k, i) => keys.indexOf(k) !== i)
+    for (const k of new Set(dupKeys)) {
+        errors.push({
+            instancePath: `${sec}/columns`,
+            message: `duplicate column key "${k}"`,
+        })
+    }
+
+    // For columns typed "status", every row's value for that key must be
+    // `{ state: <enum>, comment?: string }` per SPEC § 4.5.
+    const statusKeys: string[] = []
+    columns.forEach((c) => {
+        if (isObj(c) && c.type === 'status' && typeof c.key === 'string') {
+            statusKeys.push(c.key)
+        }
+    })
+    if (statusKeys.length > 0) {
+        rows.forEach((row, rIdx) => {
+            if (!isObj(row)) return
+            for (const key of statusKeys) {
+                const cell = row[key]
+                if (cell === undefined || cell === null) continue
+                const path = `${sec}/rows/${rIdx}/${key}`
+                if (!isObj(cell)) {
+                    errors.push({
+                        instancePath: path,
+                        message: `status cell must be an object { state, comment? }`,
+                    })
+                    continue
+                }
+                if (typeof cell.state !== 'string' || !TABLE_STATUS_STATES.has(cell.state)) {
+                    errors.push({
+                        instancePath: `${path}/state`,
+                        message: `status.state must be one of ${[...TABLE_STATUS_STATES].join('|')}`,
+                    })
+                }
+                if ('comment' in cell && cell.comment !== undefined && typeof cell.comment !== 'string') {
+                    errors.push({
+                        instancePath: `${path}/comment`,
+                        message: `status.comment must be a string if present`,
+                    })
+                }
+            }
+        })
+    }
+}
+
+function validateChecklist(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    const groups = Array.isArray(data.groups) ? data.groups : []
+    const sec = `/sections/${secIdx}/data`
+    checkUniqueIds(groups, `${sec}/groups`, errors)
+    groups.forEach((g, gi) => {
+        if (!isObj(g)) return
+        checkUniqueIds(g.items, `${sec}/groups/${gi}/items`, errors)
+    })
+}
+
+function validateNotes(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    checkUniqueIds(data.blocks, `/sections/${secIdx}/data/blocks`, errors)
+}
+
+function validateTimeline(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    const sec = `/sections/${secIdx}/data`
+    checkUniqueIds(data.items, `${sec}/items`, errors)
+    checkUniqueIds(data.milestones, `${sec}/milestones`, errors)
+}
+
+function validateLog(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    checkUniqueIds(data.entries, `/sections/${secIdx}/data/entries`, errors)
+}
+
+function validateMetrics(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    checkUniqueIds(data.cards, `/sections/${secIdx}/data/cards`, errors)
+}
+
+function validateReport(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    checkUniqueIds(data.reports, `/sections/${secIdx}/data/reports`, errors)
+}
+
+function validateForm(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    const sec = `/sections/${secIdx}/data`
+    checkUniqueIds(data.fields, `${sec}/fields`, errors)
+    checkUniqueIds(data.submissions, `${sec}/submissions`, errors)
+}
+
+function validateLinks(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    checkUniqueIds(data.items, `/sections/${secIdx}/data/items`, errors)
+}
+
+function validateReferences(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    checkUniqueIds(data.items, `/sections/${secIdx}/data/items`, errors)
+}
+
+function validateFamilyGraph(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    if (!isObj(data)) return
+    const sec = `/sections/${secIdx}/data`
+    checkUniqueIds(data.persons, `${sec}/persons`, errors)
+    const personIds = new Set(
+        (Array.isArray(data.persons) ? data.persons : [])
+            .filter(isObj)
+            .map((p) => p.id)
+            .filter((v): v is string => typeof v === 'string')
+    )
+    const rels = Array.isArray(data.relationships) ? data.relationships : []
+    rels.forEach((r, ri) => {
+        if (!isObj(r)) return
+        for (const key of ['person1Id', 'person2Id'] as const) {
+            const v = r[key]
+            if (typeof v === 'string' && !personIds.has(v)) {
+                errors.push({
+                    instancePath: `${sec}/relationships/${ri}/${key}`,
+                    message: `${key} "${v}" is not a known person id`,
+                })
+            }
+        }
+    })
+    if (typeof data.focusedPersonId === 'string' && !personIds.has(data.focusedPersonId)) {
+        errors.push({
+            instancePath: `${sec}/focusedPersonId`,
+            message: `focusedPersonId "${data.focusedPersonId}" is not a known person id`,
+        })
+    }
+}
+
+// Hard cap on diagram nesting. Schema doesn't bound `children` depth, so a
+// hostile `.agent` file could craft a 15k-deep diagram that stack-overflows
+// a naive recursive walk. This cap is well above anything a human-authored
+// org-chart / mind-map would need; exceeding it is treated as a validation
+// error rather than a crash.
+const DIAGRAM_MAX_DEPTH = 256
+
+function validateDiagram(
+    data: unknown,
+    secIdx: number,
+    errors: SemanticError[]
+): void {
+    // Diagram IDs must be unique across the entire tree (recursive).
+    if (!isObj(data) || !isObj(data.root)) return
+    const seen = new Map<string, string>()
+    const sec = `/sections/${secIdx}/data`
+    let depthExceededReported = false
+    // Check depth *before* recursing so we bail at the cap itself (not one
+    // frame past it), and emit a bounded instancePath — a pathologically
+    // deep payload would otherwise produce a multi-KB path on stderr / in
+    // the viewer UI.
+    const walk = (node: unknown, path: string, depth: number): void => {
+        if (!isObj(node)) return
+        const id = node.id
+        if (typeof id === 'string') {
+            const prior = seen.get(id)
+            if (prior !== undefined) {
+                errors.push({
+                    instancePath: path,
+                    message: `duplicate diagram node id "${id}" (first at ${prior})`,
+                })
+            } else {
+                seen.set(id, path)
+            }
+        }
+        const children = Array.isArray(node.children) ? node.children : []
+        for (let i = 0; i < children.length; i++) {
+            if (depth + 1 > DIAGRAM_MAX_DEPTH) {
+                if (!depthExceededReported) {
+                    errors.push({
+                        instancePath: `${sec}/root`,
+                        message: `diagram nesting exceeds ${DIAGRAM_MAX_DEPTH} levels — likely malformed or hostile input`,
+                    })
+                    depthExceededReported = true
+                }
+                return
+            }
+            walk(children[i], `${path}/children/${i}`, depth + 1)
+        }
+    }
+    walk(data.root, `${sec}/root`, 0)
+}
+
+export function validateSemantics(doc: unknown): SemanticError[] {
+    const errors: SemanticError[] = []
+    if (!isObj(doc)) return errors
+
+    // Top-level task IDs must be unique.
+    const config = doc.config
+    if (isObj(config) && Array.isArray(config.tasks)) {
+        checkUniqueIds(config.tasks, `/config/tasks`, errors)
+    }
+
+    const sections = Array.isArray(doc.sections) ? doc.sections : []
+    checkUniqueIds(sections, `/sections`, errors)
+
+    sections.forEach((sec, idx) => {
+        if (!isObj(sec)) return
+        const type = sec.type
+        const data = sec.data
+        switch (type) {
+            case 'kanban':
+                validateKanban(data, idx, errors)
+                break
+            case 'checklist':
+                validateChecklist(data, idx, errors)
+                break
+            case 'notes':
+                validateNotes(data, idx, errors)
+                break
+            case 'timeline':
+                validateTimeline(data, idx, errors)
+                break
+            case 'table':
+                validateTable(data, idx, errors)
+                break
+            case 'log':
+                validateLog(data, idx, errors)
+                break
+            case 'metrics':
+                validateMetrics(data, idx, errors)
+                break
+            case 'diagram':
+                validateDiagram(data, idx, errors)
+                break
+            case 'report':
+                validateReport(data, idx, errors)
+                break
+            case 'form':
+                validateForm(data, idx, errors)
+                break
+            case 'links':
+                validateLinks(data, idx, errors)
+                break
+            case 'references':
+                validateReferences(data, idx, errors)
+                break
+            case 'family-graph':
+                validateFamilyGraph(data, idx, errors)
+                break
+            default:
+                // Extension section types (`x-<vendor>:<name>`) and unknown
+                // bare types: no semantic check beyond the per-section id
+                // uniqueness already covered by the /sections sweep.
+                break
+        }
+    })
+
+    return errors
+}

--- a/packages/renderer/tests/renderer.test.tsx
+++ b/packages/renderer/tests/renderer.test.tsx
@@ -1,7 +1,7 @@
 // Smoke + security tests for the renderer. These run against every section
 // type, so regressions in defensive guards or sanitizers fail fast.
-import { describe, expect, it } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render } from '@testing-library/react'
 import {
     AgentRenderer,
     buildPrintableHtml,
@@ -448,5 +448,158 @@ describe('AgentRenderer — security', () => {
         const { container: c2 } = render(<AgentRenderer data={makeAgent([section2])} />)
         const ok = c2.querySelector('.af-label') as HTMLSpanElement | null
         expect(ok?.style.background || ok?.style.backgroundColor).toMatch(/#ff00aa|rgb\(255,\s*0,\s*170\)/i)
+    })
+})
+
+// ─── Editable kanban ──────────────────────────────────────────────────────
+// Kanban is the first section to go editable (week-2 of the round-trip work).
+// These tests pin the contract that downstream consumers (save_agent_file,
+// host-bridge writeback) will rely on.
+
+function makeKanbanAgent(): AgentFile {
+    return makeAgent([
+        {
+            id: 's1',
+            type: 'kanban',
+            label: 'Tasks',
+            order: 0,
+            data: {
+                columns: [
+                    { id: 'c_todo', name: 'To Do', category: 'todo', order: 0 },
+                    { id: 'c_done', name: 'Done', category: 'done', order: 1 },
+                ],
+                items: [
+                    {
+                        id: 'i1',
+                        title: 'Draft spec',
+                        type: 'task',
+                        status: 'c_todo',
+                        priority: 'p1',
+                        labelIds: [],
+                        blockedBy: [],
+                        createdAt: '2026-04-18T00:00:00Z',
+                        updatedAt: '2026-04-18T00:00:00Z',
+                    },
+                ],
+                labels: [],
+            },
+        },
+    ])
+}
+
+describe('AgentRenderer — editable kanban', () => {
+    it('read-only mode: cards are not draggable and double-click does not enter edit', () => {
+        const { container } = render(<AgentRenderer data={makeKanbanAgent()} />)
+        const card = container.querySelector('.af-card') as HTMLDivElement
+        expect(card.getAttribute('draggable')).not.toBe('true')
+        fireEvent.doubleClick(card.querySelector('.af-card-title')!)
+        expect(container.querySelector('.af-card-title-input')).toBeNull()
+    })
+
+    it('editable mode: cards get draggable=true when onChange is provided', () => {
+        const { container } = render(
+            <AgentRenderer data={makeKanbanAgent()} onChange={() => {}} />
+        )
+        const card = container.querySelector('.af-card') as HTMLDivElement
+        expect(card.getAttribute('draggable')).toBe('true')
+    })
+
+    it('drop fires onChange with the item moved to the target column', () => {
+        let captured: AgentFile | null = null
+        const { container } = render(
+            <AgentRenderer data={makeKanbanAgent()} onChange={(next) => (captured = next)} />
+        )
+        const card = container.querySelector('.af-card') as HTMLDivElement
+        const doneColumn = container.querySelectorAll('.af-column')[1] as HTMLDivElement
+
+        // JSDOM doesn't give us a real DataTransfer; synthesize one so the
+        // handler's getData/setData path works. Mirrors what the browser would
+        // populate for a real drag.
+        const store = new Map<string, string>()
+        const dataTransfer = {
+            types: [] as string[],
+            setData(type: string, value: string) {
+                store.set(type, value)
+                if (!this.types.includes(type)) this.types.push(type)
+            },
+            getData(type: string) {
+                return store.get(type) ?? ''
+            },
+            dropEffect: '',
+            effectAllowed: '',
+        }
+
+        fireEvent.dragStart(card, { dataTransfer })
+        fireEvent.dragOver(doneColumn, { dataTransfer })
+        fireEvent.drop(doneColumn, { dataTransfer })
+
+        expect(captured).not.toBeNull()
+        const next = captured as unknown as AgentFile
+        const kanban = next.sections[0] as Extract<Section, { type: 'kanban' }>
+        expect(kanban.data.items[0].status).toBe('c_done')
+        expect(next.updatedAt).not.toBe('2026-04-18T00:00:00Z')
+    })
+
+    it('double-click title → Enter commits a rename', () => {
+        let captured: AgentFile | null = null
+        const { container } = render(
+            <AgentRenderer
+                data={makeKanbanAgent()}
+                onChange={(next) => (captured = next)}
+            />
+        )
+        const title = container.querySelector('.af-card-title') as HTMLElement
+        fireEvent.doubleClick(title)
+        const input = container.querySelector('.af-card-title-input') as HTMLInputElement
+        expect(input).not.toBeNull()
+        fireEvent.change(input, { target: { value: 'Draft spec v2' } })
+        fireEvent.keyDown(input, { key: 'Enter' })
+
+        expect(captured).not.toBeNull()
+        const next = captured as unknown as AgentFile
+        const kanban = next.sections[0] as Extract<Section, { type: 'kanban' }>
+        expect(kanban.data.items[0].title).toBe('Draft spec v2')
+    })
+
+    it('Escape discards a rename — onChange is not called', () => {
+        const onChange = vi.fn()
+        const { container } = render(
+            <AgentRenderer data={makeKanbanAgent()} onChange={onChange} />
+        )
+        fireEvent.doubleClick(container.querySelector('.af-card-title')!)
+        const input = container.querySelector('.af-card-title-input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'should be discarded' } })
+        fireEvent.keyDown(input, { key: 'Escape' })
+        expect(onChange).not.toHaveBeenCalled()
+        expect(container.querySelector('.af-card-title-input')).toBeNull()
+    })
+
+    it('dropping a card onto its own column is a no-op — onChange is not called', () => {
+        const onChange = vi.fn()
+        const { container } = render(
+            <AgentRenderer data={makeKanbanAgent()} onChange={onChange} />
+        )
+        const card = container.querySelector('.af-card') as HTMLDivElement
+        const todoColumn = container.querySelectorAll('.af-column')[0] as HTMLDivElement
+
+        const store = new Map<string, string>()
+        const dataTransfer = {
+            types: [] as string[],
+            setData(type: string, value: string) {
+                store.set(type, value)
+                if (!this.types.includes(type)) this.types.push(type)
+            },
+            getData(type: string) {
+                return store.get(type) ?? ''
+            },
+            dropEffect: '',
+            effectAllowed: '',
+        }
+
+        fireEvent.dragStart(card, { dataTransfer })
+        fireEvent.dragOver(todoColumn, { dataTransfer })
+        fireEvent.drop(todoColumn, { dataTransfer })
+
+        expect(onChange).not.toHaveBeenCalled()
     })
 })

--- a/packages/renderer/tests/sanitize-no-dom.test.ts
+++ b/packages/renderer/tests/sanitize-no-dom.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+//
+// Exercises the regex fallback in sanitizeSvgForEmbed that runs when no
+// DOMParser is available (bare Node, serverless cold paths). The main
+// renderer suite runs under happy-dom, so DOMParser is always defined and
+// the fallback never fires — this file plugs that hole.
+import { describe, expect, it } from 'vitest'
+import { sanitizeSvgForEmbed } from '../src'
+
+function decodeEntities(s: string): string {
+    return s
+        .replace(/&#x([0-9a-f]+);?/gi, (_m, hex: string) =>
+            String.fromCharCode(parseInt(hex, 16))
+        )
+        .replace(/&#([0-9]+);?/g, (_m, dec: string) =>
+            String.fromCharCode(parseInt(dec, 10))
+        )
+}
+
+describe('sanitize.ts regex fallback (no DOMParser)', () => {
+    it('has DOMParser genuinely absent in this environment', () => {
+        // Sanity: if happy-dom leaked in somehow, every assertion below
+        // would be testing the DOM path instead of the regex fallback.
+        expect(typeof (globalThis as { DOMParser?: unknown }).DOMParser).toBe(
+            'undefined'
+        )
+    })
+
+    it.each([
+        ['script tag', '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'],
+        ['namespaced script', '<svg xmlns:svg="http://www.w3.org/2000/svg"><svg:script>alert(1)</svg:script></svg>'],
+        ['style with url(javascript:)', '<svg><style>*{background:url(javascript:alert(1))}</style></svg>'],
+        ['foreignObject+iframe', '<svg><foreignObject><iframe src="javascript:alert(1)"></iframe></foreignObject></svg>'],
+        ['javascript: href', '<svg><a href="javascript:alert(1)"><text>x</text></a></svg>'],
+        ['entity-encoded javascript: href', '<svg><a href="&#106;avascript:alert(1)"><text>x</text></a></svg>'],
+        ['&colon; entity scheme', '<svg><a href="javascript&colon;alert(1)"><text>x</text></a></svg>'],
+        ['on* handler', '<svg><circle onclick="alert(1)" cx="5" cy="5" r="1"/></svg>'],
+        ['style attribute', '<svg><g style="background:url(javascript:alert(1))"/></svg>'],
+        ['SMIL animate hijack', '<svg><a href="#safe"><animate attributeName="href" to="javascript:alert(1)"/><text>x</text></a></svg>'],
+        ['external <use href>', '<svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="https://evil.example/x.svg#y"/></svg>'],
+    ])('neutralizes: %s', (_label, dirty) => {
+        const clean = sanitizeSvgForEmbed(dirty)
+        const normalized = decodeEntities(clean).replace(/[\s\0]/g, '').toLowerCase()
+        expect(normalized).not.toContain('javascript:')
+        expect(normalized).not.toContain('vbscript:')
+        expect(normalized).not.toMatch(/<script/i)
+        expect(normalized).not.toMatch(/<style/i)
+        expect(normalized).not.toMatch(/<foreignobject/i)
+        expect(normalized).not.toMatch(/onerror|onload|onclick|onmouseover/i)
+        expect(normalized).not.toMatch(/use[^>]+href="https/i)
+    })
+
+    it('is allowlist-based: strips unknown tags not explicitly listed', () => {
+        // `<marquee>`, `<form>`, `<input>`, `<xyz>` are not SVG allowlist
+        // entries — under a true allowlist they must be stripped, even
+        // though they were never in any explicit blocklist. The DOM path
+        // drops them; the fallback must do the same.
+        const dirty = `<svg xmlns="http://www.w3.org/2000/svg">
+          <marquee>scroll</marquee>
+          <form action="https://evil.example"><input name="p"/></form>
+          <xyz foo="bar">text</xyz>
+          <circle cx="5" cy="5" r="1"/>
+        </svg>`
+        const clean = sanitizeSvgForEmbed(dirty)
+        expect(clean).not.toMatch(/<marquee/i)
+        expect(clean).not.toMatch(/<form/i)
+        expect(clean).not.toMatch(/<input/i)
+        expect(clean).not.toMatch(/<xyz/i)
+        // The safe geometry survives.
+        expect(clean).toMatch(/cx="5"/)
+    })
+
+    it('strips SVG <image> (external image loader)', () => {
+        // SVG <image href="..."/> loads cross-origin resources. It is not
+        // an allowlisted element, so the fallback must remove it even
+        // though it is not explicitly in destroyTags-by-name in older
+        // fallback implementations.
+        const dirty = '<svg><image href="https://evil.example/pixel.gif" x="0" y="0" width="1" height="1"/></svg>'
+        const clean = sanitizeSvgForEmbed(dirty)
+        expect(clean).not.toMatch(/<image/i)
+        expect(clean).not.toMatch(/evil\.example/)
+    })
+
+    it('strips HTML comments (can hide tag-smuggling payloads)', () => {
+        const dirty = '<svg><!-- <script>alert(1)</script> --><circle cx="1" cy="1" r="1"/></svg>'
+        const clean = sanitizeSvgForEmbed(dirty)
+        expect(clean).not.toContain('<!--')
+        expect(clean).not.toMatch(/<script/i)
+    })
+
+    it('strips CDATA sections', () => {
+        const dirty = '<svg><![CDATA[<script>alert(1)</script>]]><circle cx="1" cy="1" r="1"/></svg>'
+        const clean = sanitizeSvgForEmbed(dirty)
+        expect(clean).not.toContain('<![CDATA[')
+        expect(clean).not.toMatch(/<script/i)
+    })
+
+    it('preserves safe allowlisted geometry', () => {
+        const dirty = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+          <g><path d="M0 0L10 10"/><circle cx="5" cy="5" r="2"/><text x="1" y="1">hello</text></g>
+        </svg>`
+        const clean = sanitizeSvgForEmbed(dirty)
+        expect(clean).toMatch(/<svg/)
+        expect(clean).toMatch(/<g/)
+        expect(clean).toMatch(/<path/)
+        expect(clean).toMatch(/<circle/)
+        expect(clean).toMatch(/<text/)
+        expect(clean).toMatch(/hello/)
+    })
+
+    it('returns empty string on empty / non-string input', () => {
+        expect(sanitizeSvgForEmbed('')).toBe('')
+        // @ts-expect-error — deliberate bad input
+        expect(sanitizeSvgForEmbed(null)).toBe('')
+        // @ts-expect-error — deliberate bad input
+        expect(sanitizeSvgForEmbed(123)).toBe('')
+    })
+})

--- a/packages/viewer/.gitignore
+++ b/packages/viewer/.gitignore
@@ -6,3 +6,5 @@ dist/
 .idea/
 *.tsbuildinfo
 .vite/
+# Generated at build time by scripts/build-validator.mjs.
+src/generated/

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -11,10 +11,13 @@
   },
   "type": "module",
   "scripts": {
+    "build:validator": "node scripts/build-validator.mjs",
+    "predev": "npm run build:validator",
+    "prebuild": "npm run build:validator",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "npm run build:validator && tsc --noEmit"
   },
   "dependencies": {
     "@agent-format/jp-court": "*",
@@ -26,6 +29,8 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "ajv": "^8.17.0",
+    "ajv-formats": "^3.0.0",
     "typescript": "^5.4.0",
     "vite": "^5.4.0"
   }

--- a/packages/viewer/scripts/build-validator.mjs
+++ b/packages/viewer/scripts/build-validator.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Pre-compile the .agent JSON Schema into a standalone ES module so the
+// browser viewer doesn't need runtime `new Function(...)` code generation.
+// Ajv's default compile path uses eval, which the viewer's strict CSP
+// (`script-src 'self'`) refuses — that made the module throw at import
+// time and left the page blank. `ajv/dist/standalone` emits pure code
+// we can bundle directly; no eval, CSP stays tight.
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const Ajv2020 = require('ajv/dist/2020').default
+const addFormats = require('ajv-formats').default
+const standaloneCode = require('ajv/dist/standalone').default
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(here, '../../..')
+const schemaPath = resolve(repoRoot, 'schemas/agent.schema.json')
+const outDir = resolve(here, '../src/generated')
+const outPath = resolve(outDir, 'agent-validator.js')
+
+const schema = JSON.parse(readFileSync(schemaPath, 'utf8'))
+const ajv = new Ajv2020({
+    code: { source: true, esm: true },
+    allErrors: true,
+    strict: false,
+})
+addFormats(ajv)
+const validate = ajv.compile(schema)
+const code = standaloneCode(ajv, validate)
+
+// ajv-standalone's `esm: true` controls only the top-level export syntax —
+// internal references to format helpers and the ucs2length runtime are
+// still emitted as CommonJS `require(...)` calls, which the browser can't
+// resolve. Rewrite them into ESM imports hoisted to the top of the file so
+// the module loads under the viewer's strict CSP.
+const esmImports = new Map([
+    ['ajv/dist/runtime/ucs2length', '__ucs2length'],
+    ['ajv-formats/dist/formats', '__ajvFormats'],
+])
+let rewritten = code
+for (const [mod, local] of esmImports) {
+    const escaped = mod.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    // `require("mod").default` → `__mod.default`, `require("mod").x.y` → `__mod.x.y`
+    rewritten = rewritten.replace(
+        new RegExp(`require\\("${escaped}"\\)`, 'g'),
+        local
+    )
+}
+const importBlock = [...esmImports.entries()]
+    .map(([mod, local]) => `import * as ${local} from "${mod}";`)
+    .join('\n')
+
+mkdirSync(outDir, { recursive: true })
+const banner =
+    '// GENERATED — do not edit. Produced by scripts/build-validator.mjs from\n' +
+    '// schemas/agent.schema.json. Re-run `npm run build:validator` to refresh.\n' +
+    '/* eslint-disable */\n'
+writeFileSync(outPath, banner + importBlock + '\n' + rewritten, 'utf8')
+process.stderr.write(`wrote ${outPath} (${code.length} bytes)\n`)

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -1,6 +1,7 @@
 import { Component, useCallback, useEffect, useState, type ReactNode } from 'react'
 import { AgentRenderer, type AgentFile } from '@agent-format/renderer'
 import { jpCourtPlugin } from '@agent-format/jp-court'
+import { validateAgentDoc } from './validator'
 
 // Plugins registered in the deployed viewer. Registering jp-court here so
 // `family-graph` sections with `variant: "jp-court"` get the Japanese-legal
@@ -37,11 +38,12 @@ class RenderErrorBoundary extends Component<
 const MAX_REMOTE_BYTES = 5 * 1024 * 1024
 const REMOTE_FETCH_TIMEOUT_MS = 15_000
 
+type ValidationIssue = { instancePath: string; message: string }
 type LoadState =
     | { kind: 'empty' }
     | { kind: 'loading' }
     | { kind: 'ok'; data: AgentFile }
-    | { kind: 'error'; message: string }
+    | { kind: 'error'; message: string; issues?: ValidationIssue[] }
 
 export function App() {
     const [state, setState] = useState<LoadState>({ kind: 'empty' })
@@ -49,15 +51,32 @@ export function App() {
     const [dragging, setDragging] = useState(false)
 
     const loadFromJson = useCallback((text: string) => {
+        let parsed: unknown
         try {
-            const parsed = JSON.parse(text) as AgentFile
-            if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.sections)) {
-                throw new Error('Input does not look like an agent file (missing sections array).')
-            }
-            setState({ kind: 'ok', data: parsed })
+            parsed = JSON.parse(text)
         } catch (err) {
-            setState({ kind: 'error', message: err instanceof Error ? err.message : String(err) })
+            setState({
+                kind: 'error',
+                message: `Not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+            })
+            return
         }
+        const result = validateAgentDoc(parsed)
+        if (!result.ok) {
+            const head =
+                result.stage === 'schema'
+                    ? 'Schema validation failed — this does not conform to the .agent v0.1 schema.'
+                    : 'Semantic validation failed — the file parses but breaks referential / uniqueness rules.'
+            const total = result.errors.length
+            const shown = result.errors.slice(0, 20)
+            const message =
+                total > shown.length
+                    ? `${head} (showing first ${shown.length} of ${total} issues)`
+                    : head
+            setState({ kind: 'error', message, issues: shown })
+            return
+        }
+        setState({ kind: 'ok', data: parsed as AgentFile })
     }, [])
 
     const loadFromUrl = useCallback(
@@ -252,7 +271,20 @@ export function App() {
                 </div>
             </div>
 
-            {state.kind === 'error' && <div className="error">{state.message}</div>}
+            {state.kind === 'error' && (
+                <div className="error">
+                    <div>{state.message}</div>
+                    {state.issues && state.issues.length > 0 && (
+                        <ul style={{ marginTop: 8, paddingLeft: 18 }}>
+                            {state.issues.map((iss, i) => (
+                                <li key={i}>
+                                    <code>{iss.instancePath || '/'}</code>: {iss.message}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            )}
             {state.kind === 'loading' && <p style={{ marginTop: 16 }}>Loading…</p>}
 
             <div className="helper">

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -49,6 +49,7 @@ export function App() {
     const [state, setState] = useState<LoadState>({ kind: 'empty' })
     const [pasted, setPasted] = useState('')
     const [dragging, setDragging] = useState(false)
+    const [editMode, setEditMode] = useState(false)
 
     const loadFromJson = useCallback((text: string) => {
         let parsed: unknown
@@ -76,7 +77,32 @@ export function App() {
             setState({ kind: 'error', message, issues: shown })
             return
         }
+        setEditMode(false)
         setState({ kind: 'ok', data: parsed as AgentFile })
+    }, [])
+
+    const updateRenderedDoc = useCallback((next: AgentFile) => {
+        setState({ kind: 'ok', data: next })
+    }, [])
+
+    const downloadJson = useCallback((data: AgentFile) => {
+        const json = JSON.stringify(data, null, 2)
+        const blob = new Blob([json], { type: 'application/json' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        const stem = data.name
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+        a.href = url
+        a.download = `${stem || 'agent-file'}.agent.json`
+        a.rel = 'noopener'
+        document.body.appendChild(a)
+        a.click()
+        window.setTimeout(() => {
+            document.body.removeChild(a)
+            URL.revokeObjectURL(url)
+        }, 100)
     }, [])
 
     const loadFromUrl = useCallback(
@@ -190,20 +216,33 @@ export function App() {
         return (
             <div className="viewer-shell">
                 <div className="toolbar">
-                    <strong>{state.data.name || 'Agent file'}</strong>
+                    <strong>agent-format</strong>
                     <span style={{ color: 'var(--af-fg-muted, #6b7280)' }}>
                         · {state.data.sections.length} sections · spec v{state.data.version}
                     </span>
                     <div className="right">
                         <button
+                            className={`btn btn-secondary${editMode ? ' is-active' : ''}`}
+                            onClick={() => setEditMode((v) => !v)}
+                        >
+                            {editMode ? '編集モード終了' : '編集モード'}
+                        </button>
+                        <button
+                            className="btn btn-secondary"
+                            onClick={() => downloadJson(state.data)}
+                        >
+                            JSON を保存
+                        </button>
+                        <button
                             className="btn btn-secondary"
                             onClick={() => {
                                 setState({ kind: 'empty' })
                                 setPasted('')
+                                setEditMode(false)
                                 window.history.replaceState(null, '', window.location.pathname)
                             }}
                         >
-                            Load another
+                            別のファイルを開く
                         </button>
                     </div>
                 </div>
@@ -211,7 +250,9 @@ export function App() {
                     <AgentRenderer
                         data={state.data}
                         plugins={VIEWER_PLUGINS}
+                        showDocumentHeader={false}
                         showOpenInViewer={false}
+                        onChange={editMode ? updateRenderedDoc : undefined}
                     />
                 </RenderErrorBoundary>
             </div>

--- a/packages/viewer/src/index.css
+++ b/packages/viewer/src/index.css
@@ -105,6 +105,12 @@ body {
     border: 1px solid var(--af-border, #e5e7eb);
 }
 
+.btn.is-active {
+    border-color: var(--af-accent, #2251ff);
+    color: var(--af-accent, #2251ff);
+    background: var(--af-accent-soft, #eef2ff);
+}
+
 .error {
     margin-top: 12px;
     padding: 10px 12px;
@@ -159,4 +165,10 @@ body {
     background: var(--af-bg-alt, #f7f7f8);
     padding: 1px 5px;
     border-radius: 3px;
+}
+
+@media print {
+    .toolbar {
+        display: none !important;
+    }
 }

--- a/packages/viewer/src/validator.ts
+++ b/packages/viewer/src/validator.ts
@@ -1,0 +1,54 @@
+// Full two-stage validator for the public viewer.
+// Stage 1: pre-compiled Ajv validator against `schemas/agent.schema.json`
+// — same schema the CLI and MCP server use. Generated at build time by
+// scripts/build-validator.mjs so the browser bundle doesn't need runtime
+// `new Function(...)` code generation (the viewer's CSP refuses eval).
+// Stage 2: the renderer's semantic validator (ID uniqueness, kanban refs,
+// table status-cell shape) — same function the CLI exercises.
+//
+// @ts-expect-error — generated JS has no co-located .d.ts; runtime shape
+// is `(data) => boolean` plus an `.errors` array set as a side effect.
+// eslint-disable-next-line import/no-unresolved
+import ajvValidate from './generated/agent-validator.js'
+import { validateSemantics } from '@agent-format/renderer'
+
+type AjvValidateFn = {
+    (data: unknown): boolean
+    errors?: { instancePath?: string; message?: string }[] | null
+}
+type IssueEntry = { instancePath: string; message: string }
+
+const validate = ajvValidate as unknown as AjvValidateFn
+
+function toIssues(errs: unknown): IssueEntry[] {
+    if (!Array.isArray(errs)) return []
+    return errs.map((e) => {
+        const obj = e as { instancePath?: string; message?: string }
+        return {
+            instancePath: obj.instancePath || '/',
+            message: obj.message ?? 'invalid',
+        }
+    })
+}
+
+export type ValidationResult =
+    | { ok: true; doc: unknown }
+    | { ok: false; stage: 'schema' | 'semantic'; errors: IssueEntry[] }
+
+export function validateAgentDoc(doc: unknown): ValidationResult {
+    if (!validate(doc)) {
+        return { ok: false, stage: 'schema', errors: toIssues(validate.errors) }
+    }
+    const semantic = validateSemantics(doc)
+    if (semantic.length > 0) {
+        return {
+            ok: false,
+            stage: 'semantic',
+            errors: semantic.map((e) => ({
+                instancePath: e.instancePath,
+                message: e.message,
+            })),
+        }
+    }
+    return { ok: true, doc }
+}

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -159,6 +159,7 @@
         "role": { "type": "string" },
         "birthday": { "type": "string" },
         "address": { "type": "string" },
+        "isLastAddress": { "type": "boolean" },
         "deathDate": { "type": "string" },
         "aliases": { "type": "array", "items": { "type": "string" } }
       },


### PR DESCRIPTION
## Summary
This PR adds an interactive edit flow for the `jp-court` family-graph variant in the standalone viewer.

It introduces a viewer-level edit mode, node hitboxes on the court diagram, a localized Japanese editor popover, and a persisted `isLastAddress` flag so address labels can explicitly render as `最後の住所` when needed.

## What Changed
- added edit mode and JSON export controls to the standalone viewer
- hid duplicate document header chrome in the viewer host
- made `AgentRenderer` optionally hide the document header when the host already provides top-level chrome
- added interactive node selection and editing to the `@agent-format/jp-court` plugin
- localized the editor UI to Japanese and improved the popover styling/layout
- added outside-click dismissal for the popover editor
- added `FamilyGraphPerson.isLastAddress` to the renderer types and JSON schema

## Why
The `jp-court` renderer produced a strong printable artifact, but users had no direct way to edit the family tree visually in the web viewer. This closes that gap while keeping the print/PDF output clean and preserving explicit document data instead of relying on renderer-only inference.

## Impact
Japanese users can now click people in the diagram to edit fields, add/remove related nodes, and export the updated `.agent` JSON. Print/PDF output stays focused on the court-style diagram without editor controls.

## Validation
- `npm run build`
- `npm run test`
