### PR TITLE
[codex] add interactive jp-court family graph editing

### DIFF
--- a/packages/jp-court/src/index.tsx
+++ b/packages/jp-court/src/index.tsx
@@ -10,12 +10,15 @@
 // can see the full family graph without the "silently dropped ancestors"
 // bug of the previous core renderer.
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { ReactElement } from 'react'
 import {
     downloadPrintableHtml,
+    useSectionChange,
     useHost,
     type RendererPlugin,
+    type FamilyGraphSection,
+    type InheritanceDiagramSection,
     type VariantRendererProps,
 } from '@agent-format/renderer'
 
@@ -28,6 +31,7 @@ interface Person {
     role?: string
     birthday?: string
     address?: string
+    isLastAddress?: boolean
     deathDate?: string
 }
 interface Rel {
@@ -63,6 +67,7 @@ type RenderedBlock = {
     elements: ReactElement[]
     nameBaseY: number
     blockEndY: number
+    overlay: OverlayBox
 }
 
 type ChildGroupResult = {
@@ -71,9 +76,27 @@ type ChildGroupResult = {
     endY: number
 }
 
-function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererProps) {
+type OverlayBox = {
+    id: string
+    name: string
+    x: number
+    y: number
+    width: number
+    height: number
+}
+
+type FamilyGraphVariantSection = FamilyGraphSection | InheritanceDiagramSection
+
+function JPCourtFamilyGraphView(props: VariantRendererProps) {
+    const { setHeaderActions } = props
+    const section = props.section as FamilyGraphVariantSection
     const host = useHost()
+    const onChange = useSectionChange<FamilyGraphVariantSection>()
+    const stageRef = useRef<HTMLDivElement | null>(null)
+    const editorPanelRef = useRef<HTMLDivElement | null>(null)
     const svgRef = useRef<SVGSVGElement | null>(null)
+    const [selectedId, setSelectedId] = useState<string | null>(null)
+    const [stageSize, setStageSize] = useState({ width: 0, height: 0 })
 
     const data = section.data as
         | {
@@ -85,6 +108,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
     const persons = data?.persons ?? []
     const rels = data?.relationships ?? []
     const byId = new Map(persons.map((p) => [p.id, p]))
+    const editable = !!onChange
 
     useEffect(() => {
         if (!setHeaderActions) return
@@ -121,6 +145,21 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         return () => setHeaderActions(null)
     }, [setHeaderActions, section.id, section.label, persons.length, host])
 
+    useEffect(() => {
+        const stageEl = stageRef.current
+        if (!stageEl) return
+        const syncStageSize = () => {
+            setStageSize({
+                width: stageEl.clientWidth,
+                height: stageEl.clientHeight,
+            })
+        }
+        syncStageSize()
+        const observer = new ResizeObserver(syncStageSize)
+        observer.observe(stageEl)
+        return () => observer.disconnect()
+    }, [])
+
     if (persons.length === 0) {
         return <p className="af-empty">No persons in diagram.</p>
     }
@@ -129,6 +168,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
     const focused = data?.focusedPersonId ? byId.get(data.focusedPersonId) : null
     const decedent = focused || persons.find((p) => Boolean(p.deathDate)) || persons[0]
     if (!decedent) return <p className="af-empty">No decedent.</p>
+    const activeSelectedId = selectedId && byId.has(selectedId) ? selectedId : null
 
     // --- Relationship lookups ---
     const spouseEdgeOf = (personId: string, excludeId?: string): Rel | null => {
@@ -189,8 +229,120 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         }
         return parents
     }
+    const selectedPerson = activeSelectedId ? byId.get(activeSelectedId) ?? null : null
+
+    const commitGraph = (nextPersons: Person[], nextRelationships: Rel[]) => {
+        if (!onChange) return
+        const nextFocusedPersonId =
+            data?.focusedPersonId && nextPersons.some((p) => p.id === data.focusedPersonId)
+                ? data.focusedPersonId
+                : nextPersons[0]?.id
+        onChange({
+            ...section,
+            data: {
+                ...(section.data ?? {}),
+                persons: nextPersons,
+                relationships: nextRelationships,
+                focusedPersonId: nextFocusedPersonId,
+            },
+        })
+    }
+
+    const nextPersonId = () => {
+        let n = persons.length + 1
+        let candidate = `person-${n}`
+        while (byId.has(candidate)) {
+            n += 1
+            candidate = `person-${n}`
+        }
+        return candidate
+    }
+
+    const updateSelectedField = (field: keyof Person, value: string) => {
+        if (!selectedPerson) return
+        const nextPersons = persons.map((p) => {
+            if (p.id !== selectedPerson.id) return p
+            if (field === 'name') {
+                return { ...p, name: value.trim() || '名称未設定' }
+            }
+            const normalized = value.trim()
+            return {
+                ...p,
+                [field]: normalized === '' ? undefined : value,
+            }
+        })
+        commitGraph(nextPersons, rels)
+    }
+
+    const updateSelectedBooleanField = (field: keyof Person, checked: boolean) => {
+        if (!selectedPerson) return
+        const nextPersons = persons.map((p) =>
+            p.id === selectedPerson.id ? { ...p, [field]: checked || undefined } : p
+        )
+        commitGraph(nextPersons, rels)
+    }
+
+    const addStandalonePerson = () => {
+        const id = nextPersonId()
+        const person: Person = { id, name: '新しい人物', role: 'その他' }
+        setSelectedId(id)
+        commitGraph([...persons, person], rels)
+    }
+
+    const addParent = () => {
+        if (!selectedPerson) return
+        const id = nextPersonId()
+        const person: Person = { id, name: '新しい親', role: '親' }
+        setSelectedId(id)
+        commitGraph([...persons, person], [
+            ...rels,
+            { type: 'parent-child', person1Id: id, person2Id: selectedPerson.id },
+        ])
+    }
+
+    const addChild = () => {
+        if (!selectedPerson) return
+        const id = nextPersonId()
+        const person: Person = { id, name: '新しい子', role: '相続人' }
+        const nextRelationships: Rel[] = [
+            ...rels,
+            { type: 'parent-child', person1Id: selectedPerson.id, person2Id: id },
+        ]
+        const spouse = findSpouse(selectedPerson.id)
+        if (spouse) {
+            nextRelationships.push({
+                type: 'parent-child',
+                person1Id: spouse.id,
+                person2Id: id,
+            })
+        }
+        setSelectedId(id)
+        commitGraph([...persons, person], nextRelationships)
+    }
+
+    const addSpouse = () => {
+        if (!selectedPerson || findSpouse(selectedPerson.id)) return
+        const id = nextPersonId()
+        const person: Person = { id, name: '新しい配偶者', role: '配偶者' }
+        setSelectedId(id)
+        commitGraph([...persons, person], [
+            ...rels,
+            { type: 'spouse', person1Id: selectedPerson.id, person2Id: id },
+        ])
+    }
+
+    const deleteSelected = () => {
+        if (!selectedPerson) return
+        const nextPersons = persons.filter((p) => p.id !== selectedPerson.id)
+        const nextRelationships = rels.filter(
+            (r) => r.person1Id !== selectedPerson.id && r.person2Id !== selectedPerson.id
+        )
+        setSelectedId(nextPersons[0]?.id ?? null)
+        commitGraph(nextPersons, nextRelationships)
+    }
 
     // --- Rendering helpers ---
+    const overlayBoxes: OverlayBox[] = []
     const blockHeight = (p: Person): number => {
         let n = 0
         if (p.address) n++
@@ -210,10 +362,10 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         const elements: ReactElement[] = []
         let y = topY
         if (p.address) {
-            const lbl = roleLabel === '被相続人' ? '最後の住所' : '住所'
+            const addressLabel = p.isLastAddress ? '最後の住所' : '住所'
             elements.push(
                 <text key={nextKey()} x={x} y={y} fontSize="11pt">
-                    {`${lbl}　${p.address}`}
+                    {`${addressLabel}　${p.address}`}
                 </text>
             )
             y += LINE_H
@@ -254,7 +406,16 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         )
         const nameBaseY = y
         y += NAME_LINE_H
-        return { elements, nameBaseY, blockEndY: y }
+        const overlay = {
+            id: p.id,
+            name: p.name,
+            x: Math.max(0, x - 10),
+            y: Math.max(0, topY - 8),
+            width: 240,
+            height: y - topY + 8,
+        }
+        overlayBoxes.push(overlay)
+        return { elements, nameBaseY, blockEndY: y, overlay }
     }
 
     // --- Measure helpers for descendants (same as original) ---
@@ -410,6 +571,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         topY: number
         bottomY: number
         elements: ReactElement[]
+        overlay: OverlayBox
     }
     const ancestorByPersonId = new Map<string, AncestorBlock>()
 
@@ -449,6 +611,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         const els: ReactElement[] = []
         let y = topY + LINE_H
         if (p.address) {
+            const addressLabel = p.isLastAddress ? '最後の住所' : '住所'
             els.push(
                 <text
                     key={nextKey()}
@@ -456,7 +619,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
                     y={y}
                     fontSize="10pt"
                 >
-                    {`住所　${truncate(p.address, 18)}`}
+                    {`${addressLabel}　${truncate(p.address, 18)}`}
                 </text>
             )
             y += LINE_H - 4
@@ -518,6 +681,14 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
             topY,
             bottomY,
             elements: els,
+            overlay: {
+                id: p.id,
+                name: p.name,
+                x: leftX,
+                y: topY,
+                width: ancestorBlockW,
+                height: bottomY - topY + 10,
+            },
         }
     }
 
@@ -550,6 +721,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
         topY: decTopY,
         bottomY: dec.blockEndY,
         elements: [],
+        overlay: dec.overlay,
     })
 
     // Render ancestor rows from bottom (nearest parent) upward to the top.
@@ -574,6 +746,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
                 ancestorByPersonId.set(parent.id, block)
                 renderedParents.push(block)
                 ancestorElements.push(...block.elements)
+                overlayBoxes.push(block.overlay)
                 cursorX += ancestorBlockW + 30
             }
             // Spouse double-line between two-parent pairs.
@@ -754,6 +927,7 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
             }
             const b = renderAncestorBlock(p, ox, oy, p.role || 'その他')
             otherElements.push(...b.elements)
+            overlayBoxes.push(b.overlay)
             ox += ancestorBlockW + 30
             otherEndY = Math.max(otherEndY, b.bottomY)
         }
@@ -761,6 +935,185 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
     }
 
     const svgH = Math.max(baseBottomY, otherEndY) + 30
+    const selectedOverlay =
+        editable && selectedPerson
+            ? overlayBoxes.find((overlay) => overlay.id === selectedPerson.id) ?? null
+            : null
+    const renderEditorAsPopover =
+        Boolean(selectedOverlay) && stageSize.width >= 920 && stageSize.height > 0
+    let editorPopoverStyle:
+        | {
+              left: string
+              top: string
+              width: string
+              maxHeight: string
+          }
+        | undefined
+    if (renderEditorAsPopover && selectedOverlay) {
+        const margin = 16
+        const panelWidth = Math.min(380, Math.max(320, stageSize.width * 0.32))
+        const scaleX = stageSize.width / 1400
+        const scaleY = stageSize.height / svgH
+        const preferredLeft = (selectedOverlay.x + selectedOverlay.width + 18) * scaleX
+        const fallbackLeft = selectedOverlay.x * scaleX - panelWidth - 18
+        let left =
+            preferredLeft + panelWidth <= stageSize.width - margin
+                ? preferredLeft
+                : fallbackLeft
+        left = Math.max(margin, Math.min(left, stageSize.width - panelWidth - margin))
+        const estimatedHeight = 340
+        let top = selectedOverlay.y * scaleY
+        if (top + estimatedHeight > stageSize.height - margin) {
+            top = Math.max(margin, stageSize.height - estimatedHeight - margin)
+        }
+        const maxHeight = Math.max(220, stageSize.height - top - margin)
+        editorPopoverStyle = {
+            left: `${left}px`,
+            top: `${top}px`,
+            width: `${panelWidth}px`,
+            maxHeight: `${maxHeight}px`,
+        }
+    }
+
+    useEffect(() => {
+        if (!renderEditorAsPopover || !selectedPerson) return
+        const onPointerDown = (event: PointerEvent) => {
+            const target = event.target
+            if (!(target instanceof Node)) return
+            if (editorPanelRef.current?.contains(target)) return
+            if (
+                target instanceof Element &&
+                target.closest('.af-jp-court-node-hitbox')
+            ) {
+                return
+            }
+            setSelectedId(null)
+        }
+        document.addEventListener('pointerdown', onPointerDown)
+        return () => document.removeEventListener('pointerdown', onPointerDown)
+    }, [renderEditorAsPopover, selectedPerson])
+
+    const editorPanel = editable ? (
+        <div
+            ref={editorPanelRef}
+            className={`af-jp-court-editor-panel${
+                renderEditorAsPopover ? ' af-jp-court-editor-panel--popover' : ''
+            }`}
+            style={renderEditorAsPopover ? editorPopoverStyle : undefined}
+        >
+            <div className="af-jp-court-editor-toolbar">
+                <button type="button" className="af-action-btn" onClick={addStandalonePerson}>
+                    人物を追加
+                </button>
+                <button
+                    type="button"
+                    className="af-action-btn"
+                    onClick={addParent}
+                    disabled={!selectedPerson}
+                >
+                    親を追加
+                </button>
+                <button
+                    type="button"
+                    className="af-action-btn"
+                    onClick={addChild}
+                    disabled={!selectedPerson}
+                >
+                    子を追加
+                </button>
+                <button
+                    type="button"
+                    className="af-action-btn"
+                    onClick={addSpouse}
+                    disabled={!selectedPerson || Boolean(selectedPerson && findSpouse(selectedPerson.id))}
+                >
+                    配偶者を追加
+                </button>
+                <button
+                    type="button"
+                    className="af-action-btn"
+                    onClick={deleteSelected}
+                    disabled={!selectedPerson}
+                >
+                    人物を削除
+                </button>
+            </div>
+            <p className="af-jp-court-editor-note">
+                図の人物をクリックして内容を編集できます。
+            </p>
+            {selectedPerson ? (
+                <>
+                    <p className="af-jp-court-editor-selected">
+                        <strong>{selectedPerson.name}</strong> を編集中
+                    </p>
+                    <div className="af-jp-court-editor-grid">
+                        <div className="af-jp-court-editor-field af-jp-court-editor-field--full">
+                            <label htmlFor={`${section.id}-person-address`}>住所</label>
+                            <input
+                                id={`${section.id}-person-address`}
+                                type="text"
+                                value={selectedPerson.address ?? ''}
+                                onChange={(e) => updateSelectedField('address', e.target.value)}
+                            />
+                        </div>
+                        <div className="af-jp-court-editor-field af-jp-court-editor-field--full">
+                            <label className="af-jp-court-editor-checkbox">
+                                <input
+                                    type="checkbox"
+                                    checked={Boolean(selectedPerson.isLastAddress)}
+                                    onChange={(e) =>
+                                        updateSelectedBooleanField(
+                                            'isLastAddress',
+                                            e.target.checked
+                                        )
+                                    }
+                                />
+                                <span>住所ラベルを「最後の住所」にする</span>
+                            </label>
+                        </div>
+                        <div className="af-jp-court-editor-field">
+                            <label htmlFor={`${section.id}-person-birthday`}>生年月日</label>
+                            <input
+                                id={`${section.id}-person-birthday`}
+                                type="text"
+                                value={selectedPerson.birthday ?? ''}
+                                onChange={(e) => updateSelectedField('birthday', e.target.value)}
+                            />
+                        </div>
+                        <div className="af-jp-court-editor-field">
+                            <label htmlFor={`${section.id}-person-death`}>死亡日</label>
+                            <input
+                                id={`${section.id}-person-death`}
+                                type="text"
+                                value={selectedPerson.deathDate ?? ''}
+                                onChange={(e) => updateSelectedField('deathDate', e.target.value)}
+                            />
+                        </div>
+                        <div className="af-jp-court-editor-field">
+                            <label htmlFor={`${section.id}-person-role`}>続柄</label>
+                            <input
+                                id={`${section.id}-person-role`}
+                                type="text"
+                                value={selectedPerson.role ?? ''}
+                                onChange={(e) => updateSelectedField('role', e.target.value)}
+                            />
+                        </div>
+                        <div className="af-jp-court-editor-field af-jp-court-editor-field--full">
+                            <label htmlFor={`${section.id}-person-name`}>氏名</label>
+                            <input
+                                id={`${section.id}-person-name`}
+                                type="text"
+                                value={selectedPerson.name}
+                                onChange={(e) => updateSelectedField('name', e.target.value)}
+                            />
+                        </div>
+                    </div>
+                </>
+            ) : (
+                <p className="af-jp-court-editor-empty">編集する人物を図から選択してください。</p>
+            )}
+        </div>
+    ) : null
 
     // The jp-court template is a legal print artifact — always black-on-white
     // per court-filing convention. Force the panel's own theme here so a
@@ -777,17 +1130,43 @@ function JPCourtFamilyGraphView({ section, setHeaderActions }: VariantRendererPr
                 borderRadius: 6,
             }}
         >
-            <svg
-                ref={svgRef}
-                xmlns="http://www.w3.org/2000/svg"
-                width="100%"
-                viewBox={`0 0 1400 ${svgH}`}
-                style={{ overflow: 'visible' }}
-                role="img"
-                aria-label="相続関係説明図"
-            >
-                {svgParts}
-            </svg>
+            <div ref={stageRef} className="af-jp-court-stage">
+                <svg
+                    ref={svgRef}
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="100%"
+                    viewBox={`0 0 1400 ${svgH}`}
+                    style={{ overflow: 'visible' }}
+                    role="img"
+                    aria-label="相続関係説明図"
+                >
+                    {svgParts}
+                </svg>
+                {editable && (
+                    <div className="af-jp-court-editor-layer">
+                        {overlayBoxes.map((overlay) => (
+                            <button
+                                key={overlay.id}
+                                type="button"
+                                className={`af-jp-court-node-hitbox${
+                                    overlay.id === activeSelectedId ? ' is-selected' : ''
+                                }`}
+                                style={{
+                                    left: `${(overlay.x / 1400) * 100}%`,
+                                    top: `${(overlay.y / svgH) * 100}%`,
+                                    width: `${(overlay.width / 1400) * 100}%`,
+                                    height: `${(overlay.height / svgH) * 100}%`,
+                                }}
+                                onClick={() => setSelectedId(overlay.id)}
+                                aria-label={`${overlay.name} を編集`}
+                                title={`${overlay.name} を編集`}
+                            />
+                        ))}
+                    </div>
+                )}
+                {renderEditorAsPopover && editorPanel}
+            </div>
+            {!renderEditorAsPopover && editorPanel}
         </div>
     )
 }

--- a/packages/renderer/src/index.tsx
+++ b/packages/renderer/src/index.tsx
@@ -72,6 +72,12 @@ interface AgentRendererProps {
      */
     host?: HostBridge
     /**
+     * Controls visibility of the document title/description header.
+     * Default: true. Set to false when the host already renders its own
+     * top-level file chrome and repeating the document title wastes space.
+     */
+    showDocumentHeader?: boolean
+    /**
      * Controls visibility of the header "Open in browser" action.
      * Default: true. Set to false when the renderer is already used inside
      * the public viewer itself (avoids a self-referential button).
@@ -83,21 +89,62 @@ interface AgentRendererProps {
      * Earlier plugins win on conflicting `(sectionType, variant)` pairs.
      */
     plugins?: ReadonlyArray<RendererPlugin>
+    /**
+     * If provided, the renderer becomes editable: section views that support
+     * edits (starting with kanban) surface drag-and-drop and inline-edit
+     * affordances, and call this with the next document state on every edit.
+     * When omitted, the renderer stays read-only — existing callers keep
+     * their current behavior unchanged.
+     */
+    onChange?: (next: AgentFile) => void
+}
+
+const SectionChangeContext = createContext<((next: Section) => void) | undefined>(
+    undefined
+)
+
+/**
+ * A section view that supports edits consumes this to receive a typed
+ * change callback: `const onChange = useSectionChange<KanbanSection>()`.
+ * Returns `undefined` in read-only mode.
+ */
+export function useSectionChange<S extends Section>(): ((next: S) => void) | undefined {
+    const cb = useContext(SectionChangeContext)
+    return cb as ((next: S) => void) | undefined
 }
 
 export function AgentRenderer({
     data,
     className,
     host,
+    showDocumentHeader = true,
     showOpenInViewer = true,
     plugins = [],
+    onChange,
 }: AgentRendererProps) {
     const sections = [...data.sections].sort((a, b) => a.order - b.order)
     const docMajor = parseVersionMajor(data.version)
     const unsupportedMajor = docMajor !== null && docMajor > SPEC_MAJOR
 
+    // Fold a typed section edit into the full AgentFile and bump updatedAt
+    // so downstream writers (save_agent_file, git diffs) see the change.
+    // Memoized so context consumers don't re-run unnecessarily.
+    const handleSectionChange = onChange
+        ? (nextSection: Section): void => {
+              const nextSections = data.sections.map((s) =>
+                  s.id === nextSection.id ? nextSection : s
+              )
+              onChange({
+                  ...data,
+                  sections: nextSections,
+                  updatedAt: new Date().toISOString(),
+              })
+          }
+        : undefined
+
     return (
         <HostContext.Provider value={host}>
+            <SectionChangeContext.Provider value={handleSectionChange}>
             <PluginsContext.Provider value={plugins}>
                 <div className={`af-root ${className ?? ''}`}>
                     {unsupportedMajor && (
@@ -119,35 +166,37 @@ export function AgentRenderer({
                             best-effort fallbacks — unknown fields may be ignored.
                         </div>
                     )}
-                    <header className="af-header">
-                        <div className="af-header-main">
-                            <h1 className="af-title">
-                                {data.icon && <span>{data.icon}</span>}
-                                <span>{data.name}</span>
-                            </h1>
-                            {data.description && (
-                                <p className="af-description">{data.description}</p>
-                            )}
-                        </div>
-                        {showOpenInViewer && (
-                            <div className="af-header-actions">
-                                <button
-                                    type="button"
-                                    className="af-action-btn"
-                                    onClick={() => {
-                                        // Fire-and-forget; ignore host denial —
-                                        // user will notice if the page didn't
-                                        // open and can retry.
-                                        void openInViewer(data, host)
-                                    }}
-                                    title="Open this file in the public agent-format viewer (new tab)"
-                                >
-                                    <span aria-hidden>↗</span>
-                                    <span>Open in browser</span>
-                                </button>
+                    {showDocumentHeader && (
+                        <header className="af-header">
+                            <div className="af-header-main">
+                                <h1 className="af-title">
+                                    {data.icon && <span>{data.icon}</span>}
+                                    <span>{data.name}</span>
+                                </h1>
+                                {data.description && (
+                                    <p className="af-description">{data.description}</p>
+                                )}
                             </div>
-                        )}
-                    </header>
+                            {showOpenInViewer && (
+                                <div className="af-header-actions">
+                                    <button
+                                        type="button"
+                                        className="af-action-btn"
+                                        onClick={() => {
+                                            // Fire-and-forget; ignore host denial —
+                                            // user will notice if the page didn't
+                                            // open and can retry.
+                                            void openInViewer(data, host)
+                                        }}
+                                        title="Open this file in the public agent-format viewer (new tab)"
+                                    >
+                                        <span aria-hidden>↗</span>
+                                        <span>Open in browser</span>
+                                    </button>
+                                </div>
+                            )}
+                        </header>
+                    )}
                     <div className="af-sections">
                         {sections.map((section) => (
                             <SectionFrame key={section.id} section={section} />
@@ -155,6 +204,7 @@ export function AgentRenderer({
                     </div>
                 </div>
             </PluginsContext.Provider>
+            </SectionChangeContext.Provider>
         </HostContext.Provider>
     )
 }

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -184,9 +184,35 @@
     cursor: grab;
 }
 
+.af-card--dragging {
+    opacity: 0.4;
+}
+
+.af-column--drop-target {
+    outline: 2px dashed var(--af-accent, #3b82f6);
+    outline-offset: -2px;
+}
+
 .af-card-title {
     font-weight: 600;
     margin: 0 0 4px;
+}
+
+.af-card-title--editable {
+    cursor: text;
+}
+
+.af-card-title-input {
+    font: inherit;
+    font-weight: 600;
+    width: 100%;
+    margin: 0 0 4px;
+    padding: 2px 4px;
+    border: 1px solid var(--af-accent, #3b82f6);
+    border-radius: 3px;
+    background: var(--af-bg);
+    color: inherit;
+    box-sizing: border-box;
 }
 
 .af-card-desc {
@@ -785,5 +811,188 @@
     }
     .af-inheritance-diagram svg text {
         fill: #000;
+    }
+}
+
+.af-jp-court-stage {
+    position: relative;
+}
+
+.af-jp-court-editor-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.af-jp-court-node-hitbox {
+    position: absolute;
+    pointer-events: auto;
+    border: 1px dashed transparent;
+    border-radius: 10px;
+    background: transparent;
+    cursor: pointer;
+}
+
+.af-jp-court-node-hitbox:hover,
+.af-jp-court-node-hitbox:focus-visible {
+    border-color: rgba(34, 81, 255, 0.5);
+    background: rgba(34, 81, 255, 0.06);
+    outline: none;
+}
+
+.af-jp-court-node-hitbox.is-selected {
+    border-color: rgba(34, 81, 255, 0.85);
+    background: rgba(34, 81, 255, 0.1);
+    box-shadow: 0 0 0 2px rgba(34, 81, 255, 0.12);
+}
+
+.af-jp-court-editor-panel {
+    margin-top: 16px;
+    padding: 18px;
+    border: 1px solid rgba(93, 128, 255, 0.28);
+    border-radius: 16px;
+    background:
+        linear-gradient(180deg, rgba(23, 26, 34, 0.97), rgba(15, 17, 24, 0.97));
+    color: #eef2ff;
+    box-shadow:
+        0 20px 50px rgba(15, 17, 24, 0.28),
+        0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+}
+
+.af-jp-court-editor-panel--popover {
+    position: absolute;
+    z-index: 4;
+    margin-top: 0;
+    overflow: auto;
+    backdrop-filter: blur(12px);
+}
+
+.af-jp-court-editor-toolbar {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+    margin-bottom: 16px;
+    padding-bottom: 14px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.af-jp-court-editor-toolbar .af-action-btn {
+    background: rgba(255, 255, 255, 0.06);
+    color: #f8fafc;
+    border-color: rgba(148, 163, 184, 0.22);
+}
+
+.af-jp-court-editor-toolbar .af-action-btn:hover {
+    background: rgba(93, 128, 255, 0.16);
+    border-color: rgba(93, 128, 255, 0.38);
+}
+
+.af-jp-court-editor-toolbar .af-action-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.af-jp-court-editor-note {
+    margin: 0 0 14px;
+    color: rgba(226, 232, 240, 0.74);
+    font-size: 12px;
+    line-height: 1.55;
+}
+
+.af-jp-court-editor-selected {
+    margin: 0 0 16px;
+    font-size: 13px;
+    color: rgba(241, 245, 249, 0.96);
+}
+
+.af-jp-court-editor-selected strong {
+    color: #ffffff;
+}
+
+.af-jp-court-editor-empty {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.74);
+    font-size: 13px;
+}
+
+.af-jp-court-editor-grid {
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.af-jp-court-editor-field {
+    display: grid;
+    gap: 7px;
+}
+
+.af-jp-court-editor-field--full {
+    grid-column: 1 / -1;
+}
+
+.af-jp-court-editor-field label {
+    font-size: 12px;
+    font-weight: 600;
+    color: rgba(226, 232, 240, 0.84);
+    letter-spacing: 0.01em;
+}
+
+.af-jp-court-editor-checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    user-select: none;
+    padding: 2px 0;
+}
+
+.af-jp-court-editor-checkbox input {
+    width: 16px;
+    height: 16px;
+    accent-color: #5d80ff;
+    flex: 0 0 auto;
+}
+
+.af-jp-court-editor-checkbox span {
+    font-size: 13px;
+    color: rgba(241, 245, 249, 0.92);
+    line-height: 1.4;
+}
+
+.af-jp-court-editor-field input[type='text'] {
+    width: 100%;
+    min-width: 0;
+    padding: 10px 12px;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 10px;
+    background: rgba(2, 6, 23, 0.62);
+    color: #f8fafc;
+    font: inherit;
+    box-sizing: border-box;
+    transition: border-color 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+.af-jp-court-editor-field input::placeholder {
+    color: rgba(148, 163, 184, 0.7);
+}
+
+.af-jp-court-editor-field input[type='text']:focus {
+    outline: none;
+    border-color: rgba(93, 128, 255, 0.72);
+    background: rgba(2, 6, 23, 0.82);
+    box-shadow: 0 0 0 3px rgba(93, 128, 255, 0.18);
+}
+
+@media (max-width: 900px) {
+    .af-jp-court-editor-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+@media print {
+    .af-jp-court-editor-layer,
+    .af-jp-court-editor-panel {
+        display: none !important;
     }
 }

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -293,6 +293,7 @@ export interface FamilyGraphPerson {
     role?: string // free text, renderer-dependent (e.g. 被相続人 / grandparent / 代襲相続人)
     birthday?: string // free text (any calendar / format)
     address?: string
+    isLastAddress?: boolean
     deathDate?: string
     aliases?: string[]
 }

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -49,6 +49,7 @@ export function App() {
     const [state, setState] = useState<LoadState>({ kind: 'empty' })
     const [pasted, setPasted] = useState('')
     const [dragging, setDragging] = useState(false)
+    const [editMode, setEditMode] = useState(false)
 
     const loadFromJson = useCallback((text: string) => {
         let parsed: unknown
@@ -76,7 +77,32 @@ export function App() {
             setState({ kind: 'error', message, issues: shown })
             return
         }
+        setEditMode(false)
         setState({ kind: 'ok', data: parsed as AgentFile })
+    }, [])
+
+    const updateRenderedDoc = useCallback((next: AgentFile) => {
+        setState({ kind: 'ok', data: next })
+    }, [])
+
+    const downloadJson = useCallback((data: AgentFile) => {
+        const json = JSON.stringify(data, null, 2)
+        const blob = new Blob([json], { type: 'application/json' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        const stem = data.name
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+        a.href = url
+        a.download = `${stem || 'agent-file'}.agent.json`
+        a.rel = 'noopener'
+        document.body.appendChild(a)
+        a.click()
+        window.setTimeout(() => {
+            document.body.removeChild(a)
+            URL.revokeObjectURL(url)
+        }, 100)
     }, [])
 
     const loadFromUrl = useCallback(
@@ -190,20 +216,33 @@ export function App() {
         return (
             <div className="viewer-shell">
                 <div className="toolbar">
-                    <strong>{state.data.name || 'Agent file'}</strong>
+                    <strong>agent-format</strong>
                     <span style={{ color: 'var(--af-fg-muted, #6b7280)' }}>
                         · {state.data.sections.length} sections · spec v{state.data.version}
                     </span>
                     <div className="right">
                         <button
+                            className={`btn btn-secondary${editMode ? ' is-active' : ''}`}
+                            onClick={() => setEditMode((v) => !v)}
+                        >
+                            {editMode ? '編集モード終了' : '編集モード'}
+                        </button>
+                        <button
+                            className="btn btn-secondary"
+                            onClick={() => downloadJson(state.data)}
+                        >
+                            JSON を保存
+                        </button>
+                        <button
                             className="btn btn-secondary"
                             onClick={() => {
                                 setState({ kind: 'empty' })
                                 setPasted('')
+                                setEditMode(false)
                                 window.history.replaceState(null, '', window.location.pathname)
                             }}
                         >
-                            Load another
+                            別のファイルを開く
                         </button>
                     </div>
                 </div>
@@ -211,7 +250,9 @@ export function App() {
                     <AgentRenderer
                         data={state.data}
                         plugins={VIEWER_PLUGINS}
+                        showDocumentHeader={false}
                         showOpenInViewer={false}
+                        onChange={editMode ? updateRenderedDoc : undefined}
                     />
                 </RenderErrorBoundary>
             </div>

--- a/packages/viewer/src/index.css
+++ b/packages/viewer/src/index.css
@@ -105,6 +105,12 @@ body {
     border: 1px solid var(--af-border, #e5e7eb);
 }
 
+.btn.is-active {
+    border-color: var(--af-accent, #2251ff);
+    color: var(--af-accent, #2251ff);
+    background: var(--af-accent-soft, #eef2ff);
+}
+
 .error {
     margin-top: 12px;
     padding: 10px 12px;
@@ -159,4 +165,10 @@ body {
     background: var(--af-bg-alt, #f7f7f8);
     padding: 1px 5px;
     border-radius: 3px;
+}
+
+@media print {
+    .toolbar {
+        display: none !important;
+    }
 }

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -159,6 +159,7 @@
         "role": { "type": "string" },
         "birthday": { "type": "string" },
         "address": { "type": "string" },
+        "isLastAddress": { "type": "boolean" },
         "deathDate": { "type": "string" },
         "aliases": { "type": "array", "items": { "type": "string" } }
       },


### PR DESCRIPTION
## Summary
This PR adds an interactive edit flow for the `jp-court` family-graph variant in the standalone viewer.

It introduces a viewer-level edit mode, node hitboxes on the court diagram, a localized Japanese editor popover, and a persisted `isLastAddress` flag so address labels can explicitly render as `最後の住所` when needed.

## What Changed
- added edit mode and JSON export controls to the standalone viewer
- hid duplicate document header chrome in the viewer host
- made `AgentRenderer` optionally hide the document header when the host already provides top-level chrome
- added interactive node selection and editing to the `@agent-format/jp-court` plugin
- localized the editor UI to Japanese and improved the popover styling/layout
- added outside-click dismissal for the popover editor
- added `FamilyGraphPerson.isLastAddress` to the renderer types and JSON schema

## Why
The `jp-court` renderer produced a strong printable artifact, but users had no direct way to edit the family tree visually in the web viewer. This closes that gap while keeping the print/PDF output clean and preserving explicit document data instead of relying on renderer-only inference.

## Impact
Japanese users can now click people in the diagram to edit fields, add/remove related nodes, and export the updated `.agent` JSON. Print/PDF output stays focused on the court-style diagram without editor controls.

## Validation
- `npm run build`
- `npm run test`
