### PR TITLE
[codex] prep npm release for interactive jp-court editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format follows semver; see `SPEC.md` § 5 for what counts as breaking.
 
 ## [Unreleased] — spec v0.1 hardening
 
+### Renderer / jp-court / viewer
+
+- `@agent-format/renderer` is now editable for host-driven section updates via
+  `onChange`, `useSectionChange`, and optional document-header suppression for
+  embedded hosts.
+- `@agent-format/jp-court` now supports interactive family-graph editing:
+  node hitboxes, localized Japanese editor popover, add/remove person flows,
+  outside-click dismissal, and explicit `isLastAddress` address labeling.
+- The standalone viewer now exposes a dedicated edit mode for `jp-court`
+  family graphs, JSON download, and cleaner host chrome without duplicate
+  document headers.
+
 ### Spec / schema
 
 - Root documents now MAY carry a `$schema` string for editor integration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5165,10 +5165,10 @@
     },
     "packages/jp-court": {
       "name": "@agent-format/jp-court",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
-        "@agent-format/renderer": "^0.1.5",
+        "@agent-format/renderer": "^0.1.6",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "react": "^19.0.0",
@@ -5177,18 +5177,18 @@
         "typescript": "^6.0.3"
       },
       "peerDependencies": {
-        "@agent-format/renderer": "^0.1.5",
+        "@agent-format/renderer": "^0.1.6",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
       }
     },
     "packages/mcp": {
       "name": "@agent-format/mcp",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
-        "@agent-format/jp-court": "0.1.2",
-        "@agent-format/renderer": "0.1.5",
+        "@agent-format/jp-court": "0.1.3",
+        "@agent-format/renderer": "0.1.6",
         "@modelcontextprotocol/ext-apps": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ajv": "^8.17.0",
@@ -5694,7 +5694,7 @@
     },
     "packages/renderer": {
       "name": "@agent-format/renderer",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^19.0.0",

--- a/packages/jp-court/package.json
+++ b/packages/jp-court/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-format/jp-court",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "@agent-format/renderer plugin: jp-court (相続関係説明図) visual template for family-graph sections. Japanese legal-filing typography, double-line spouse edges, PDF export. Does NOT filter persons — the .agent file is the source of truth.",
   "license": "MIT",
   "author": "Yuya Morita",
@@ -32,12 +32,12 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@agent-format/renderer": "^0.1.5",
+    "@agent-format/renderer": "^0.1.6",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },
   "devDependencies": {
-    "@agent-format/renderer": "^0.1.5",
+    "@agent-format/renderer": "^0.1.6",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "react": "^19.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-format/mcp",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "MCP Apps server that renders .agent files as interactive dashboards inline in Claude / ChatGPT / Cursor / VS Code Copilot.",
   "license": "MIT",
   "author": "Yuya Morita",
@@ -26,8 +26,8 @@
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.ui.json"
   },
   "dependencies": {
-    "@agent-format/jp-court": "0.1.2",
-    "@agent-format/renderer": "0.1.5",
+    "@agent-format/jp-court": "0.1.3",
+    "@agent-format/renderer": "0.1.6",
     "@modelcontextprotocol/ext-apps": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ajv": "^8.17.0",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-format/renderer",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "React renderer for the agent file format (.agent).",
   "license": "MIT",
   "author": "Yuya Morita",


### PR DESCRIPTION
## Summary
This PR prepares npm release tags for the interactive `jp-court` family-graph editing work that has already landed on `main`.

It bumps the published package versions, updates internal dependency pins, and adds a changelog entry describing the renderer / jp-court / viewer changes.

## What Changed
- bumped `@agent-format/renderer` from `0.1.5` to `0.1.6`
- bumped `@agent-format/jp-court` from `0.1.2` to `0.1.3`
- bumped `@agent-format/mcp` from `0.1.9` to `0.1.10`
- updated `@agent-format/mcp` to depend on the new renderer and jp-court versions
- updated `@agent-format/jp-court` peer/dev dependency ranges for `@agent-format/renderer`
- added a changelog entry covering the interactive jp-court editing release

## Why
The interactive jp-court editor changes are merged, but npm publishing in this repo is tag-driven and version-checked. Without version bumps, the release workflow cannot publish updated packages for npm consumers.

## Validation
- `npm run build`
- `npm run test`
