### PR TITLE
[codex] bump mcp to 0.2.1 for npm latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format follows semver; see `SPEC.md` § 5 for what counts as breaking.
 
 ### MCP
 
+- `@agent-format/mcp` continues this release line as `0.2.1` so npm can
+  publish it as `latest` above the already-published `0.2.0`.
 - `render_agent_inline` now validates the full document against the JSON
   Schema via Ajv and returns a structured error on failure instead of
   shallow "is `sections` an array?" check.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5184,7 +5184,7 @@
     },
     "packages/mcp": {
       "name": "@agent-format/mcp",
-      "version": "0.1.10",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@agent-format/jp-court": "0.1.3",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-format/mcp",
-  "version": "0.1.10",
+  "version": "0.2.1",
   "description": "MCP Apps server that renders .agent files as interactive dashboards inline in Claude / ChatGPT / Cursor / VS Code Copilot.",
   "license": "MIT",
   "author": "Yuya Morita",


### PR DESCRIPTION
## Summary
This follow-up release PR bumps @agent-format/mcp from 0.1.10 to 0.2.1.

npm already has @agent-format/mcp@0.2.0, so the previous 0.1.10 release could not be published as latest. This keeps the interactive jp-court editing work publishable on the main npm line.

## Changes
- bumped @agent-format/mcp from 0.1.10 to 0.2.1
- updated the workspace lockfile entry
- noted the npm release-line reason in the changelog

## Validation
- npm run build -w @agent-format/mcp
- npm run typecheck -w @agent-format/mcp

## Note
npm pack --dry-run --workspace @agent-format/mcp hit a local ~/.npm cache ownership issue, not a repo/package failure.