### PR TITLE
Fix viewer open-in-browser share links

### DIFF
--- a/packages/renderer/src/actions.ts
+++ b/packages/renderer/src/actions.ts
@@ -9,11 +9,7 @@
 import type { AgentFile } from './types'
 import { type HostBridge, fallbackOpenLink, fallbackDownload } from './host'
 import { sanitizeSvgForEmbed } from './sanitize'
-
-// Public viewer endpoint for the `.agent` format. The `#<encoded-json>` hash
-// form is documented in packages/viewer/src/App.tsx and stable across
-// viewer versions (renders the data client-side, no upload).
-const VIEWER_URL = 'https://knorq-ai.github.io/agent-format/'
+import { buildViewerUrl } from './share'
 
 const VALID_PAGE_SIZES = new Map<string, string>([
     ['a5', 'A5'],
@@ -45,10 +41,9 @@ export async function openInViewer(
     data: AgentFile,
     host?: HostBridge
 ): Promise<boolean> {
-    const json = JSON.stringify(data)
     // Hash fragment is never sent to the server, so sensitive data (legal
     // documents, audit logs) stays on the client.
-    const url = `${VIEWER_URL}#${encodeURIComponent(json)}`
+    const url = buildViewerUrl(data)
     if (host?.openLink) return host.openLink(url)
     return fallbackOpenLink(url)
 }

--- a/packages/renderer/src/index.tsx
+++ b/packages/renderer/src/index.tsx
@@ -28,6 +28,11 @@ export {
     buildPrintableHtml,
     downloadPrintableHtml,
 } from './actions'
+export {
+    buildViewerUrl,
+    encodeViewerHashPayload,
+    decodeViewerHashPayload,
+} from './share'
 export { sanitizeSvgForEmbed } from './sanitize'
 export { validateSemantics, type SemanticError } from './validate'
 

--- a/packages/renderer/src/share.ts
+++ b/packages/renderer/src/share.ts
@@ -1,0 +1,64 @@
+import type { AgentFile } from './types'
+
+const VIEWER_URL = 'https://knorq-ai.github.io/agent-format/'
+const INLINE_HASH_PREFIX = 'b64:'
+const BASE64_CHUNK_SIZE = 0x8000
+
+export function buildViewerUrl(data: AgentFile): string {
+    const json = JSON.stringify(data)
+    return `${VIEWER_URL}#${encodeViewerHashPayload(json)}`
+}
+
+export function encodeViewerHashPayload(json: string): string {
+    const bytes = new TextEncoder().encode(json)
+    return `${INLINE_HASH_PREFIX}${bytesToBase64Url(bytes)}`
+}
+
+export function decodeViewerHashPayload(hash: string): string {
+    const raw = hash.startsWith('#') ? hash.slice(1) : hash
+    if (!raw) throw new Error('Missing inline viewer payload.')
+
+    if (raw.startsWith(INLINE_HASH_PREFIX)) {
+        const encoded = raw.slice(INLINE_HASH_PREFIX.length)
+        if (!encoded) throw new Error('Missing base64 payload.')
+        const bytes = base64UrlToBytes(encoded)
+        return new TextDecoder().decode(bytes)
+    }
+
+    try {
+        return decodeURIComponent(raw)
+    } catch (error) {
+        throw new Error(
+            `Invalid inline viewer payload: ${error instanceof Error ? error.message : String(error)}`
+        )
+    }
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+    let binary = ''
+    for (let i = 0; i < bytes.length; i += BASE64_CHUNK_SIZE) {
+        const chunk = bytes.subarray(i, i + BASE64_CHUNK_SIZE)
+        binary += String.fromCharCode(...chunk)
+    }
+    return toBase64(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+function base64UrlToBytes(input: string): Uint8Array {
+    const base64 = input.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=')
+    const binary = fromBase64(padded)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+    return bytes
+}
+
+function toBase64(binary: string): string {
+    if (typeof globalThis.btoa === 'function') return globalThis.btoa(binary)
+    throw new Error('Base64 encoding is unavailable in this environment.')
+}
+
+function fromBase64(base64: string): string {
+    if (typeof globalThis.atob === 'function') return globalThis.atob(base64)
+    throw new Error('Base64 decoding is unavailable in this environment.')
+}
+

--- a/packages/renderer/tests/share.test.ts
+++ b/packages/renderer/tests/share.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+    buildViewerUrl,
+    decodeViewerHashPayload,
+    encodeViewerHashPayload,
+} from '../src/index'
+
+describe('viewer share payloads', () => {
+    it('round-trips unicode JSON through the base64url hash format', () => {
+        const json = JSON.stringify({
+            version: '0.1',
+            name: '北国家相続関係説明図',
+            icon: '🧓👩‍⚖️',
+        })
+
+        const encoded = encodeViewerHashPayload(json)
+
+        expect(encoded.startsWith('b64:')).toBe(true)
+        expect(decodeViewerHashPayload(encoded)).toBe(json)
+    })
+
+    it('keeps decoding the legacy percent-encoded hash format', () => {
+        const json = JSON.stringify({ name: '山田太郎', icon: '🧾' })
+
+        expect(decodeViewerHashPayload(encodeURIComponent(json))).toBe(json)
+    })
+
+    it('builds shorter urls than percent-encoding for unicode-heavy documents', () => {
+        const data = {
+            version: '0.1',
+            name: '北国家相続関係説明図',
+            icon: '🧓👩‍⚖️',
+            sections: [],
+        } as const
+
+        const url = buildViewerUrl(data as any)
+        const legacy = `https://knorq-ai.github.io/agent-format/#${encodeURIComponent(JSON.stringify(data))}`
+
+        expect(url).toContain('#b64:')
+        expect(url.length).toBeLessThan(legacy.length)
+    })
+})

--- a/packages/viewer/README.md
+++ b/packages/viewer/README.md
@@ -12,7 +12,7 @@ Standalone web viewer for [`.agent`](https://github.com/knorq-ai/agent-format) f
 | File picker | Click the drop zone |
 | Paste | Paste JSON into the textarea, click Render |
 | URL | `/?url=https://example.com/my.agent` |
-| Hash | `/#{encodeURIComponent(jsonString)}` |
+| Hash | `/#b64:{base64url(utf8(jsonString))}` |
 
 ## Development
 

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -1,5 +1,9 @@
 import { Component, useCallback, useEffect, useState, type ReactNode } from 'react'
-import { AgentRenderer, type AgentFile } from '@agent-format/renderer'
+import {
+    AgentRenderer,
+    decodeViewerHashPayload,
+    type AgentFile,
+} from '@agent-format/renderer'
 import { jpCourtPlugin } from '@agent-format/jp-court'
 import { validateAgentDoc } from './validator'
 
@@ -182,16 +186,22 @@ export function App() {
         const params = new URLSearchParams(window.location.search)
         const urlParam = params.get('url')
         if (urlParam) {
-            loadFromUrl(urlParam)
+            void loadFromUrl(urlParam)
             return
         }
         const hash = window.location.hash
         if (hash && hash.length > 1) {
             try {
-                const decoded = decodeURIComponent(hash.slice(1))
+                const decoded = decodeViewerHashPayload(hash)
                 loadFromJson(decoded)
-            } catch {
-                // ignore; fall through to empty state
+            } catch (error) {
+                setState({
+                    kind: 'error',
+                    message:
+                        error instanceof Error
+                            ? error.message
+                            : 'Invalid inline viewer payload.',
+                })
             }
         }
     }, [loadFromUrl, loadFromJson])
@@ -330,7 +340,7 @@ export function App() {
 
             <div className="helper">
                 Sharing options: <code>?url=&lt;url&gt;</code> fetches and renders a remote file.{' '}
-                <code>#&lt;encoded-json&gt;</code> renders inline data from the URL hash. See the{' '}
+                <code>#&lt;inline-data&gt;</code> renders inline data from the URL hash. See the{' '}
                 <a href="https://github.com/knorq-ai/agent-format">spec</a> for file format details.
             </div>
         </div>


### PR DESCRIPTION
## Summary
- switch inline viewer share links from percent-encoded JSON to compact `b64:` base64url payloads
- keep the viewer backward-compatible with legacy hash links and show inline payload parse errors instead of falling back to a blank landing state
- document the new hash format and cover unicode-heavy payloads with renderer tests

## Verification
- `npm test -- --run packages/renderer/tests/share.test.ts packages/renderer/tests/renderer.test.tsx`
- `npm run typecheck -w @agent-format/renderer`
- `npm run typecheck -w @agent-format/viewer`
- `npm run build -w @agent-format/viewer`