### PR TITLE
Fix viewer validator under production Vite/esbuild CJS interop

### DIFF
--- a/packages/viewer/scripts/build-validator.mjs
+++ b/packages/viewer/scripts/build-validator.mjs
@@ -36,38 +36,59 @@ const code = standaloneCode(ajv, validate)
 // still emitted as CommonJS `require(...)` calls, which the browser can't
 // resolve. Rewrite them into ESM imports hoisted to the top of the file so
 // the module loads under the viewer's strict CSP.
-const esmImports = new Map([
+//
+// The rewrite swaps each known `require("mod")[...suffix]` pattern with a
+// normalized alias that matches the exact shape the generated code expects.
+// This matters because esbuild's `__toESM(..., 1)` (Node-compat) interop sets
+// `ns.default = module.exports`, so naively substituting `require("m")` with
+// the namespace `ns` would land on `ns.default.prop` instead of `exports.prop`
+// — turning `func2 = require("ucs2length").default` into the CJS exports
+// object rather than the ucs2length function. AJV standalone only emits three
+// reference shapes, so we rewrite each one explicitly and define matching
+// aliases below.
+const namespaceImports = new Map([
     ['ajv/dist/runtime/ucs2length', '__ucs2lengthImport'],
     ['ajv-formats/dist/formats', '__ajvFormatsImport'],
 ])
+const referenceRewrites = [
+    // `require("…/ucs2length").default` is the ucs2length function itself.
+    {
+        pattern: /require\("ajv\/dist\/runtime\/ucs2length"\)\.default/g,
+        replacement: '__ucs2length',
+    },
+    // `require("ajv-formats/dist/formats")` resolves to the CJS exports
+    // namespace (with `.fullFormats`, `.fastFormats`, etc. attached).
+    {
+        pattern: /require\("ajv-formats\/dist\/formats"\)/g,
+        replacement: '__ajvFormats',
+    },
+]
 let rewritten = code
-for (const [mod, local] of esmImports) {
-    const escaped = mod.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    // `require("mod").default` → `__mod.default`, `require("mod").x.y` → `__mod.x.y`
-    rewritten = rewritten.replace(
-        new RegExp(`require\\("${escaped}"\\)`, 'g'),
-        local
-    )
+for (const { pattern, replacement } of referenceRewrites) {
+    rewritten = rewritten.replace(pattern, replacement)
 }
-const importBlock = [...esmImports.entries()]
+const importBlock = [...namespaceImports.entries()]
     .map(([mod, local]) => `import * as ${local} from "${mod}";`)
     .join('\n')
 const interopBlock = [
-    // Ajv standalone emits CommonJS helper references. Under Vite's ESM +
-    // CommonJS interop, these helpers may surface as nested `default.default`
-    // objects instead of the callable/value the generated code expects.
-    // Normalize both modules once here so the generated validator stays stable
-    // in browser bundles and in tests.
-    'const __ucs2length = typeof __ucs2lengthImport.default === "function"',
-    '    ? __ucs2lengthImport.default',
-    '    : typeof __ucs2lengthImport.default?.default === "function"',
-    '        ? __ucs2lengthImport.default.default',
-    '        : __ucs2lengthImport.default ?? __ucs2lengthImport;',
-    'const __ajvFormats = __ajvFormatsImport.fullFormats',
-    '    ? __ajvFormatsImport',
-    '    : __ajvFormatsImport.default?.fullFormats',
-    '        ? __ajvFormatsImport.default',
-    '        : __ajvFormatsImport.default ?? __ajvFormatsImport;',
+    // Normalize esbuild/Vite CJS interop shapes. The generated code references
+    // `__ucs2length` (expected to be the function) and `__ajvFormats` (expected
+    // to be the CJS exports namespace that exposes `.fullFormats`). Under
+    // esbuild's Node-compat `__toESM` wrapper, the bare ESM namespace object
+    // puts the real values one level deep inside `.default`; unwrap that.
+    'const __ucs2length = (() => {',
+    '    const ns = __ucs2lengthImport;',
+    '    if (typeof ns === "function") return ns;',
+    '    if (ns && typeof ns.default === "function") return ns.default;',
+    '    if (ns && ns.default && typeof ns.default.default === "function") return ns.default.default;',
+    '    throw new Error("agent-format viewer: ucs2length runtime helper missing");',
+    '})();',
+    'const __ajvFormats = (() => {',
+    '    const ns = __ajvFormatsImport;',
+    '    if (ns && ns.fullFormats) return ns;',
+    '    if (ns && ns.default && ns.default.fullFormats) return ns.default;',
+    '    throw new Error("agent-format viewer: ajv-formats runtime helper missing");',
+    '})();',
 ].join('\n')
 
 mkdirSync(outDir, { recursive: true })

--- a/packages/viewer/tests/validator-bundled.test.ts
+++ b/packages/viewer/tests/validator-bundled.test.ts
@@ -1,0 +1,92 @@
+// Regression test for the CJS-interop bug that produced `P is not a function`
+// (minified `func2 is not a function`) in the deployed viewer.
+//
+// The plain vitest test validates `src/validator.ts` under Node's native
+// ESM-from-CJS interop, which exposes named exports directly. The viewer ships
+// through Vite, which uses esbuild's `__toESM(mod, 1)` (Node-compat) wrapper —
+// that sets `ns.default = module.exports`, one level deeper than Node's own
+// interop. The original bug only surfaced there, so this test bundles the
+// generated validator through esbuild with the same settings Vite uses and
+// asserts it stays callable end-to-end.
+import { describe, expect, it } from 'vitest'
+import { build } from 'esbuild'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+
+async function runBundledValidator(fixture: string): Promise<{
+    ok: boolean
+    errors?: unknown
+    thrown?: string
+}> {
+    const workDir = mkdtempSync(resolve(tmpdir(), 'agent-validator-'))
+    const validatorPath = resolve(
+        process.cwd(),
+        'packages/viewer/src/generated/agent-validator.js'
+    )
+    const fixtureData = readFileSync(resolve(process.cwd(), fixture), 'utf8')
+    // Sanity-check that the fixture itself is valid JSON before we inline it;
+    // a malformed fixture would otherwise surface as a confusing parser error
+    // inside the bundled entry.
+    JSON.parse(fixtureData)
+    const entryPath = resolve(workDir, 'entry.mjs')
+    const outPath = resolve(workDir, 'bundle.mjs')
+    // The entry imports the generated validator and prints a JSON verdict to
+    // stdout. We run the bundle in a child process so vitest's own module
+    // resolver doesn't interfere with the `file://` import. The fixture is
+    // inlined because esbuild's `platform: "browser"` does not resolve
+    // `node:fs`.
+    writeFileSync(
+        entryPath,
+        [
+            `import validate from ${JSON.stringify(validatorPath)};`,
+            `const data = ${fixtureData};`,
+            `try {`,
+            `    const ok = validate(data);`,
+            `    process.stdout.write(JSON.stringify({ ok, errors: validate.errors ?? null }));`,
+            `} catch (err) {`,
+            `    process.stdout.write(JSON.stringify({ ok: false, thrown: err instanceof Error ? err.message : String(err) }));`,
+            `}`,
+        ].join('\n')
+    )
+    await build({
+        entryPoints: [entryPath],
+        bundle: true,
+        format: 'esm',
+        platform: 'browser',
+        outfile: outPath,
+        resolveExtensions: ['.mjs', '.js'],
+        absWorkingDir: process.cwd(),
+        mainFields: ['browser', 'module', 'main'],
+        conditions: ['browser', 'import', 'default'],
+        logLevel: 'silent',
+    })
+    const result = spawnSync(process.execPath, [outPath], {
+        encoding: 'utf8',
+        timeout: 20_000,
+    })
+    if (result.status !== 0) {
+        return {
+            ok: false,
+            thrown: result.stderr.trim() || `exit ${result.status}`,
+        }
+    }
+    return JSON.parse(result.stdout)
+}
+
+describe('viewer validator (esbuild-bundled)', () => {
+    it('stays callable under esbuild Node-compat CJS interop (minimal)', async () => {
+        const verdict = await runBundledValidator('examples/minimal.agent')
+        expect(verdict.thrown).toBeUndefined()
+        expect(verdict.ok).toBe(true)
+    }, 30_000)
+
+    it('stays callable for jp-court fixtures with date-time + uri formats', async () => {
+        const verdict = await runBundledValidator(
+            'examples/inheritance-jp-3gen.agent'
+        )
+        expect(verdict.thrown).toBeUndefined()
+        expect(verdict.ok).toBe(true)
+    }, 30_000)
+})


### PR DESCRIPTION
## Summary
- The previous fix (#23) added normalization aliases but never wired them into the substitution — the generated validator still called `__ucs2lengthImport.default(...)`, which under esbuild's Node-compat `__toESM(mod, 1)` wrapper is the CJS exports object, not the ucs2length function. Every document validation threw `P is not a function` in the deployed viewer.
- Rewrite the three AJV standalone reference shapes directly to the normalized aliases so `require("ucs2length").default` → `__ucs2length` (function) and `require("ajv-formats/dist/formats")` → `__ajvFormats` (CJS exports namespace).
- Add a vitest regression test that bundles the generated validator through esbuild with Vite's browser settings and runs it in a child process. The test fails against the prior build-validator.mjs and passes with this fix.

## Test plan
- [x] `npm test -- --run packages/viewer/tests` (3 passed)
- [x] `npm run build -w @agent-format/viewer` (builds clean)
- [x] Regression test verified by reverting the fix — both bundled-validator tests fail
- [x] `vite preview` on the production `dist/` bundle, percent-encoded jp-court inheritance hash URL: renders 1 section with family-graph SVG, no error box, toolbar shows "1 sections · spec v0.1"
- [ ] After merge: GitHub Pages deploy runs (deploy-viewer.yml triggers on packages/viewer/** changes), then MCP's "Open in browser" → knorq-ai.github.io/agent-format renders files cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)