### PR TITLE
Bump @agent-format/mcp to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ The format follows semver; see `SPEC.md` § 5 for what counts as breaking.
 
 ### MCP
 
+- `@agent-format/mcp` bumped to `0.2.2` to pick up
+  `@agent-format/renderer@0.1.7` — hosts get dramatically shorter
+  "Open in browser" share URLs (deflate-compressed `c1:` hash payload).
 - `@agent-format/mcp` continues this release line as `0.2.1` so npm can
   publish it as `latest` above the already-published `0.2.0`.
 - `render_agent_inline` now validates the full document against the JSON

--- a/package-lock.json
+++ b/package-lock.json
@@ -5190,7 +5190,7 @@
     },
     "packages/mcp": {
       "name": "@agent-format/mcp",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@agent-format/jp-court": "0.1.3",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-format/mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "MCP Apps server that renders .agent files as interactive dashboards inline in Claude / ChatGPT / Cursor / VS Code Copilot.",
   "license": "MIT",
   "author": "Yuya Morita",


### PR DESCRIPTION
## Summary
- Bumps `@agent-format/mcp` from `0.2.1` → `0.2.2` so hosts pick up `@agent-format/renderer@0.1.7`.
- Renderer 0.1.7 introduced the deflate-compressed `c1:` share URL format — mcp users benefit from a ~77% shorter "Open in browser" URL on realistic Japanese documents.
- No mcp API changes.

## Test plan
- [x] `npm ci --dry-run` clean.
- [ ] After merge: tag `mcp-v0.2.2` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)