### PR TITLE
Promote viewer link to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **A structured alternative to HTML for AI-generated visualizations — editable by the user, re-readable by the agent.**
 
+> 🔗 **Try the viewer:** [knorq-ai.github.io/agent-format](https://knorq-ai.github.io/agent-format/) — drop any `.agent` file, paste JSON, or open a share link. No install.
+
 > Status: **Draft v0.1** — not yet stable. Expect breaking changes until v1.0.
 >
 > **Note:** Not related to [`dotagent`](https://github.com/johnlindquist/dotagent) by @johnlindquist — that tool unifies IDE rule files (CLAUDE.md / `.cursorrules` / etc.). This spec defines a typed JSON artifact format for agent-rendered dashboards.


### PR DESCRIPTION
## Summary
- Adds a one-liner near the title pointing visitors at https://knorq-ai.github.io/agent-format/ before they scroll through spec rationale.
- Repo "About" homepage URL was also set to the same URL (via `gh repo edit`) so it shows in the GitHub sidebar badge.

## Test plan
- [x] Markdown renders cleanly above the existing draft-status note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)