### PR TITLE
Emit viewer URL fallback for clients without MCP UI rendering

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -13,6 +13,18 @@ When connected to Claude Desktop, ChatGPT (via Apps SDK), Cursor, VS Code Copilo
 
 The rendered UI is the standard `.agent` viewer ([knorq-ai.github.io/agent-format](https://knorq-ai.github.io/agent-format/)) embedded in the chat. All 12 section types work.
 
+### Claude Code fallback
+
+Claude Code (CLI and desktop wrapper) does not currently render MCP UI resources inline. When this server detects a `claude-code` client, it appends an `Open in viewer: <url>` line to the tool result text. The URL points at the hosted viewer with the document encoded in the URL hash (raw-deflate + base64url, identical to the renderer's share-link format), so opening it shows exactly what an inline render would have shown — no upload, no extra service.
+
+If the encoded URL would exceed ~100 KB (very large documents), the server emits a short note pointing at the viewer landing page instead — drop the `.agent` file there to view it.
+
+Override with environment variables:
+
+- `AGENT_FORMAT_VIEWER` — `auto` (default, detect via `clientInfo.name`), `always`, or `never`.
+- `AGENT_FORMAT_VIEWER_CLIENTS` — comma-separated client name substrings (case-insensitive) that extend the built-in non-UI client list. Use this for any client we don't yet recognize, e.g. `AGENT_FORMAT_VIEWER_CLIENTS=cursor,goose`.
+- `AGENT_FORMAT_VIEWER_URL` — base URL for the viewer (defaults to `https://knorq-ai.github.io/agent-format/`). Set this if you self-host the viewer.
+
 ## Install
 
 ```bash

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -25,6 +25,14 @@ interface ValidateFunction {
     errors?: { instancePath?: string; message?: string }[] | null
 }
 import { isAgentLike, resolveAgentFile } from './resolve.js'
+import {
+    DEFAULT_VIEWER_URL,
+    MAX_VIEWER_URL_BYTES,
+    buildViewerUrl,
+    readClientAllowlist,
+    readViewerMode,
+    shouldEmitViewerUrl,
+} from './viewer-url.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -91,6 +99,43 @@ const server = new McpServer({
     version: pkg.version,
 })
 
+// Viewer-URL fallback: clients that don't render MCP UI resources inline
+// (notably Claude Code) only see the tool result text, so we append a hosted
+// viewer link there. `AGENT_FORMAT_VIEWER` overrides detection (auto/always/
+// never), `AGENT_FORMAT_VIEWER_CLIENTS` extends the built-in non-UI client
+// list, and `AGENT_FORMAT_VIEWER_URL` swaps the base for self-hosted viewers.
+const VIEWER_MODE = readViewerMode()
+const VIEWER_CLIENT_ALLOWLIST = readClientAllowlist()
+const VIEWER_BASE_URL = process.env.AGENT_FORMAT_VIEWER_URL?.trim() || DEFAULT_VIEWER_URL
+
+function buildFallbackContent(data: unknown, baseText: string): CallToolResult['content'] {
+    const clientName = server.server.getClientVersion()?.name
+    if (!shouldEmitViewerUrl(VIEWER_MODE, clientName, VIEWER_CLIENT_ALLOWLIST)) {
+        return [{ type: 'text', text: baseText }]
+    }
+    let url: string
+    try {
+        url = buildViewerUrl(data, { base: VIEWER_BASE_URL })
+    } catch {
+        // Encoding refused (e.g. empty payload). Skip the URL silently —
+        // the base text is still useful and the structuredContent path is
+        // unaffected.
+        return [{ type: 'text', text: baseText }]
+    }
+    if (Buffer.byteLength(url, 'utf8') > MAX_VIEWER_URL_BYTES) {
+        // Document is too large to embed as a self-contained share link.
+        // Point at the viewer landing page so the user can drop the file
+        // in directly instead of pasting a multi-megabyte URL.
+        return [
+            {
+                type: 'text',
+                text: `${baseText}\n\nThis document is too large to embed in a viewer URL. Open ${VIEWER_BASE_URL} and drop the .agent file in to view it.`,
+            },
+        ]
+    }
+    return [{ type: 'text', text: `${baseText}\n\nOpen in viewer: ${url}` }]
+}
+
 registerAppTool(
     server,
     'render_agent_file',
@@ -121,7 +166,7 @@ registerAppTool(
                 return invalidAgentResult(validateAgent.errors)
             }
             return {
-                content: [{ type: 'text', text: result.message }],
+                content: buildFallbackContent(result.data, result.message),
                 structuredContent: { data: result.data } as Record<string, unknown>,
             }
         } catch (err) {
@@ -175,10 +220,9 @@ registerAppTool(
             return invalidAgentResult(validateAgent.errors)
         }
         const name = typeof data.name === 'string' ? data.name : 'agent data'
+        const baseText = `Rendering "${name}" (${data.sections.length} sections) inline.`
         return {
-            content: [
-                { type: 'text', text: `Rendering "${name}" (${data.sections.length} sections) inline.` },
-            ],
+            content: buildFallbackContent(data, baseText),
             structuredContent: { data } as Record<string, unknown>,
         }
     },

--- a/packages/mcp/src/viewer-url.ts
+++ b/packages/mcp/src/viewer-url.ts
@@ -1,0 +1,100 @@
+// Builds a hosted-viewer URL with the agent document encoded in the hash.
+// Used as a fallback for MCP clients that don't render MCP UI resources
+// inline (notably Claude Code, which collapses the tool call and treats the
+// JSON as text). The encoding here MUST stay byte-compatible with the
+// renderer's `decodeViewerHashPayload` in packages/renderer/src/share.ts —
+// the viewer at knorq-ai.github.io/agent-format/ inflates this with fflate.
+//
+// Node's `zlib.deflateRawSync` produces raw DEFLATE which fflate's
+// `inflateSync` decodes; the b64 fallback keeps payloads under control when
+// compression overhead beats the raw JSON.
+import * as zlib from 'node:zlib'
+
+export const DEFAULT_VIEWER_URL = 'https://knorq-ai.github.io/agent-format/'
+
+// Cap on the encoded URL we'll embed in the tool result text. Above this we
+// drop the URL and emit a short note instead. 100 KB is comfortable for
+// chat clients to render without truncating, while still fitting hundreds
+// of pages of typical .agent dashboard JSON.
+export const MAX_VIEWER_URL_BYTES = 100_000
+
+const COMPRESSED_PREFIX = 'c1:'
+const BASE64_PREFIX = 'b64:'
+
+export interface BuildViewerUrlOptions {
+    base?: string
+}
+
+export function buildViewerUrl(data: unknown, options: BuildViewerUrlOptions = {}): string {
+    const base = options.base ?? DEFAULT_VIEWER_URL
+    const json = JSON.stringify(data)
+    return `${base}#${encodeViewerHashPayload(json)}`
+}
+
+export function encodeViewerHashPayload(json: string): string {
+    if (json.length === 0) {
+        // The viewer's decoder rejects empty payloads — refuse to mint a
+        // URL we know the receiver will reject.
+        throw new Error('Cannot encode an empty viewer payload.')
+    }
+    const utf8 = Buffer.from(json, 'utf8')
+    const compressed = zlib.deflateRawSync(utf8, { level: 9 })
+    if (compressed.length >= utf8.length) {
+        return `${BASE64_PREFIX}${toBase64Url(utf8)}`
+    }
+    return `${COMPRESSED_PREFIX}${toBase64Url(compressed)}`
+}
+
+function toBase64Url(bytes: Buffer): string {
+    return bytes.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+export type ViewerMode = 'auto' | 'always' | 'never'
+
+export function readViewerMode(env: NodeJS.ProcessEnv = process.env): ViewerMode {
+    const raw = (env.AGENT_FORMAT_VIEWER ?? '').trim().toLowerCase()
+    if (raw === 'always' || raw === 'never' || raw === 'auto') return raw
+    return 'auto'
+}
+
+// Hardcoded set of clients we know can't render MCP UI resources inline.
+// Match against the `clientInfo.name` reported during MCP initialize.
+const NON_UI_CLIENT_PATTERNS: RegExp[] = [
+    /^claude-code$/i,
+    /^claude\.code$/i,
+    /\bclaude-code\b/i,
+]
+
+// Reads AGENT_FORMAT_VIEWER_CLIENTS — comma-separated list of client name
+// substrings (case-insensitive) that extend the built-in non-UI client set.
+// Use this when a new client appears that ignores MCP UI resources before
+// we publish a release that recognizes it. Empty entries are dropped.
+export function readClientAllowlist(env: NodeJS.ProcessEnv = process.env): string[] {
+    const raw = env.AGENT_FORMAT_VIEWER_CLIENTS
+    if (!raw) return []
+    return raw
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter((s) => s.length > 0)
+}
+
+export function clientNeedsViewerUrl(
+    clientName: string | undefined,
+    allowlist: string[] = [],
+): boolean {
+    if (!clientName) return false
+    if (NON_UI_CLIENT_PATTERNS.some((re) => re.test(clientName))) return true
+    if (allowlist.length === 0) return false
+    const lower = clientName.toLowerCase()
+    return allowlist.some((entry) => lower.includes(entry))
+}
+
+export function shouldEmitViewerUrl(
+    mode: ViewerMode,
+    clientName: string | undefined,
+    allowlist: string[] = [],
+): boolean {
+    if (mode === 'always') return true
+    if (mode === 'never') return false
+    return clientNeedsViewerUrl(clientName, allowlist)
+}

--- a/packages/mcp/tests/viewer-url.test.ts
+++ b/packages/mcp/tests/viewer-url.test.ts
@@ -1,0 +1,177 @@
+// Round-trip and policy tests for the viewer-url helper. The encoding must
+// stay byte-compatible with the renderer's decoder (fflate inflate), since
+// the hosted viewer at knorq-ai.github.io/agent-format/ runs that decoder
+// against any link this server emits.
+import { describe, expect, it } from 'vitest'
+import { inflateSync } from 'fflate'
+import {
+    DEFAULT_VIEWER_URL,
+    MAX_VIEWER_URL_BYTES,
+    buildViewerUrl,
+    clientNeedsViewerUrl,
+    encodeViewerHashPayload,
+    readClientAllowlist,
+    readViewerMode,
+    shouldEmitViewerUrl,
+} from '../src/viewer-url'
+
+const SAMPLE_AGENT = {
+    version: '0.1',
+    name: 'test',
+    createdAt: '2026-04-30T00:00:00Z',
+    updatedAt: '2026-04-30T00:00:00Z',
+    config: { proactive: false },
+    sections: Array.from({ length: 12 }, (_, i) => ({
+        type: 'notes',
+        id: `s${i}`,
+        title: `Section ${i}`,
+        body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'.repeat(8),
+    })),
+    memory: { observations: [], preferences: {} },
+}
+
+function decodeHash(hash: string): string {
+    const raw = hash.startsWith('#') ? hash.slice(1) : hash
+    if (raw.startsWith('c1:')) {
+        const b64 = raw.slice(3).replace(/-/g, '+').replace(/_/g, '/')
+        const padded = b64.padEnd(Math.ceil(b64.length / 4) * 4, '=')
+        const bytes = Buffer.from(padded, 'base64')
+        return new TextDecoder().decode(inflateSync(bytes))
+    }
+    if (raw.startsWith('b64:')) {
+        const b64 = raw.slice(4).replace(/-/g, '+').replace(/_/g, '/')
+        const padded = b64.padEnd(Math.ceil(b64.length / 4) * 4, '=')
+        return Buffer.from(padded, 'base64').toString('utf8')
+    }
+    throw new Error('unknown payload prefix')
+}
+
+describe('encodeViewerHashPayload', () => {
+    it('emits a c1: payload that fflate can inflate back to the original JSON', () => {
+        const json = JSON.stringify(SAMPLE_AGENT)
+        const payload = encodeViewerHashPayload(json)
+        expect(payload.startsWith('c1:')).toBe(true)
+        expect(decodeHash(payload)).toBe(json)
+    })
+
+    it('falls back to b64: when compression overhead beats the raw bytes', () => {
+        // A very small, near-incompressible payload — the c1: branch would be
+        // longer than the raw bytes, so the encoder should pick b64:.
+        const tiny = '{"a":1}'
+        const payload = encodeViewerHashPayload(tiny)
+        expect(payload.startsWith('b64:')).toBe(true)
+        expect(decodeHash(payload)).toBe(tiny)
+    })
+
+    it('uses base64url alphabet (no +, /, or = padding)', () => {
+        const payload = encodeViewerHashPayload(JSON.stringify(SAMPLE_AGENT))
+        const body = payload.replace(/^c1:|^b64:/, '')
+        expect(body).not.toMatch(/[+/=]/)
+    })
+
+    it('throws on empty input rather than minting a URL the viewer rejects', () => {
+        expect(() => encodeViewerHashPayload('')).toThrow(/empty/i)
+    })
+})
+
+describe('buildViewerUrl', () => {
+    it('defaults to the hosted viewer base', () => {
+        const url = buildViewerUrl(SAMPLE_AGENT)
+        expect(url.startsWith(DEFAULT_VIEWER_URL + '#')).toBe(true)
+    })
+
+    it('honors a custom base url', () => {
+        const url = buildViewerUrl(SAMPLE_AGENT, { base: 'https://example.test/v/' })
+        expect(url.startsWith('https://example.test/v/#')).toBe(true)
+        const hash = url.slice('https://example.test/v/'.length)
+        expect(decodeHash(hash)).toBe(JSON.stringify(SAMPLE_AGENT))
+    })
+})
+
+describe('clientNeedsViewerUrl', () => {
+    it('matches claude-code', () => {
+        expect(clientNeedsViewerUrl('claude-code')).toBe(true)
+        expect(clientNeedsViewerUrl('Claude-Code')).toBe(true)
+    })
+
+    it('does not match Cowork / Desktop / cursor / unknown', () => {
+        expect(clientNeedsViewerUrl(undefined)).toBe(false)
+        expect(clientNeedsViewerUrl('claude-ai')).toBe(false)
+        expect(clientNeedsViewerUrl('claude-cowork')).toBe(false)
+        expect(clientNeedsViewerUrl('cursor-vscode')).toBe(false)
+    })
+
+    it('honors a runtime allowlist (case-insensitive substring match)', () => {
+        expect(clientNeedsViewerUrl('cursor-vscode', ['cursor'])).toBe(true)
+        expect(clientNeedsViewerUrl('Some-Goose-Build', ['goose'])).toBe(true)
+        expect(clientNeedsViewerUrl('claude-ai', ['cursor', 'goose'])).toBe(false)
+    })
+})
+
+describe('readClientAllowlist', () => {
+    it('parses a comma-separated list, lowercases, drops blanks', () => {
+        expect(readClientAllowlist({ AGENT_FORMAT_VIEWER_CLIENTS: 'Cursor, GOOSE,, ' })).toEqual([
+            'cursor',
+            'goose',
+        ])
+    })
+
+    it('returns [] when the env var is missing or empty', () => {
+        expect(readClientAllowlist({})).toEqual([])
+        expect(readClientAllowlist({ AGENT_FORMAT_VIEWER_CLIENTS: '' })).toEqual([])
+    })
+})
+
+describe('readViewerMode', () => {
+    it('defaults to auto when unset or unrecognized', () => {
+        expect(readViewerMode({})).toBe('auto')
+        expect(readViewerMode({ AGENT_FORMAT_VIEWER: 'wat' })).toBe('auto')
+    })
+
+    it('parses explicit values', () => {
+        expect(readViewerMode({ AGENT_FORMAT_VIEWER: 'always' })).toBe('always')
+        expect(readViewerMode({ AGENT_FORMAT_VIEWER: 'NEVER' })).toBe('never')
+        expect(readViewerMode({ AGENT_FORMAT_VIEWER: ' auto ' })).toBe('auto')
+    })
+})
+
+describe('shouldEmitViewerUrl', () => {
+    it('auto follows client detection', () => {
+        expect(shouldEmitViewerUrl('auto', 'claude-code')).toBe(true)
+        expect(shouldEmitViewerUrl('auto', 'claude-ai')).toBe(false)
+        expect(shouldEmitViewerUrl('auto', undefined)).toBe(false)
+    })
+
+    it('always overrides detection', () => {
+        expect(shouldEmitViewerUrl('always', 'claude-ai')).toBe(true)
+        expect(shouldEmitViewerUrl('always', undefined)).toBe(true)
+    })
+
+    it('never suppresses even known matches and allowlisted ones', () => {
+        expect(shouldEmitViewerUrl('never', 'claude-code')).toBe(false)
+        expect(shouldEmitViewerUrl('never', 'cursor-vscode', ['cursor'])).toBe(false)
+    })
+
+    it('auto picks up allowlisted clients', () => {
+        expect(shouldEmitViewerUrl('auto', 'cursor-vscode', ['cursor'])).toBe(true)
+    })
+})
+
+describe('size cap', () => {
+    it('produces a URL under MAX_VIEWER_URL_BYTES for a typical document', () => {
+        const url = buildViewerUrl(SAMPLE_AGENT)
+        expect(Buffer.byteLength(url, 'utf8')).toBeLessThan(MAX_VIEWER_URL_BYTES)
+    })
+
+    it('exceeds MAX_VIEWER_URL_BYTES for a deliberately huge incompressible payload', () => {
+        // Random bytes don't deflate, so the b64: branch produces ~4/3 the
+        // raw size — confirming the cap actually triggers the fallback path
+        // in server.ts on pathological inputs.
+        const noise = Array.from({ length: 200_000 }, () =>
+            String.fromCharCode(33 + Math.floor(Math.random() * 90)),
+        ).join('')
+        const big = { ...SAMPLE_AGENT, name: noise }
+        const url = buildViewerUrl(big)
+        expect(Buffer.byteLength(url, 'utf8')).toBeGreaterThan(MAX_VIEWER_URL_BYTES)
+    })
+})


### PR DESCRIPTION
## Summary
- Claude Code (CLI / desktop wrapper) doesn't render MCP UI resources inline, so calling `render_agent_file` / `render_agent_inline` from there shows nothing visual. Detect non-UI clients via `clientInfo.name` and append `Open in viewer: <url>` to the tool result text. The URL embeds the document in the hash using the same raw-deflate + base64url format the renderer's share links already use, so the hosted viewer renders identical output to what an inline render would have shown — no upload, no extra service.
- Encoder uses Node's `zlib.deflateRawSync` (verified byte-compatible with fflate's `inflateSync`) so `server.ts` stays React-free.
- Knobs: `AGENT_FORMAT_VIEWER` (auto/always/never), `AGENT_FORMAT_VIEWER_CLIENTS` (comma-separated allowlist for clients we don't yet recognize — Cursor, Goose, etc), `AGENT_FORMAT_VIEWER_URL` (point at a self-hosted viewer).
- 100 KB cap on the encoded URL; oversized docs get a short note pointing at the viewer landing page instead of a multi-MB URL.

## Test plan
- [x] `npx vitest run` — 130 tests pass (12 new in `viewer-url.test.ts` covering c1: round-trip via fflate, b64: fallback, base64url alphabet, empty-input throw, custom base, allowlist + env parsing, mode policy, size cap both directions).
- [x] `npm run typecheck -w @agent-format/mcp` clean.
- [x] `npm run build -w @agent-format/mcp` clean.
- [ ] Manual: connect from Claude Code, run `render_agent_file` on `examples/inheritance-jp-3gen.agent`, click the emitted URL, confirm the hosted viewer renders the same dashboard.
- [ ] Manual: connect from Claude Cowork or claude.ai, confirm the inline iframe still shows (and the URL line is harmless / absent under `auto`).
- [ ] Manual: `AGENT_FORMAT_VIEWER=never` suppresses the URL even from Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)