### PR TITLE
Accept null for optional FamilyGraphPerson string fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ The format follows semver; see `SPEC.md` § 5 for what counts as breaking.
 
 ### Spec / schema
 
+- `FamilyGraphPerson.role`, `birthday`, `address`, and `deathDate` now accept
+  `null` in addition to a string or being omitted. LLM-driven generators and
+  TypeScript/OpenAPI codegens routinely emit `null` for "value is absent",
+  and forcing producers to special-case alive persons (no `deathDate`) was
+  surfacing as cascading `oneOf` validation errors in the viewer. Renderers
+  treat `null` the same as the field being omitted.
 - Root documents now MAY carry a `$schema` string for editor integration.
 - Removed legacy `inheritance-diagram` section type from the schema; writers
   MUST emit `family-graph`. Renderers SHOULD continue to accept the old

--- a/SPEC.md
+++ b/SPEC.md
@@ -312,7 +312,7 @@ data: {
   persons: {
     id, name,
     role?,                           // free text; renderers may use as label
-    birthday?, deathDate?, address?,
+    birthday?, deathDate?, address?, // optional; may be omitted or `null` (treated as absent)
     aliases?: string[]
   }[],
   relationships: {

--- a/packages/jp-court/src/index.tsx
+++ b/packages/jp-court/src/index.tsx
@@ -28,11 +28,11 @@ import {
 interface Person {
     id: string
     name: string
-    role?: string
-    birthday?: string
-    address?: string
+    role?: string | null
+    birthday?: string | null
+    address?: string | null
     isLastAddress?: boolean
-    deathDate?: string
+    deathDate?: string | null
 }
 interface Rel {
     type: 'spouse' | 'parent-child'

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -290,11 +290,11 @@ export interface ReferencesSection extends SectionBase {
 export interface FamilyGraphPerson {
     id: string
     name: string
-    role?: string // free text, renderer-dependent (e.g. 被相続人 / grandparent / 代襲相続人)
-    birthday?: string // free text (any calendar / format)
-    address?: string
+    role?: string | null // free text, renderer-dependent (e.g. 被相続人 / grandparent / 代襲相続人)
+    birthday?: string | null // free text (any calendar / format)
+    address?: string | null
     isLastAddress?: boolean
-    deathDate?: string
+    deathDate?: string | null
     aliases?: string[]
 }
 

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -156,11 +156,11 @@
       "properties": {
         "id": { "type": "string", "minLength": 1 },
         "name": { "type": "string", "minLength": 1 },
-        "role": { "type": "string" },
-        "birthday": { "type": "string" },
-        "address": { "type": "string" },
+        "role": { "type": ["string", "null"] },
+        "birthday": { "type": ["string", "null"] },
+        "address": { "type": ["string", "null"] },
         "isLastAddress": { "type": "boolean" },
-        "deathDate": { "type": "string" },
+        "deathDate": { "type": ["string", "null"] },
         "aliases": { "type": "array", "items": { "type": "string" } }
       },
       "additionalProperties": false

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -109,6 +109,34 @@ describe('JSON Schema', () => {
         expect(validate(bad)).toBe(false)
     })
 
+    it('accepts null for optional FamilyGraphPerson string fields', () => {
+        const ok = {
+            ...base,
+            sections: [
+                {
+                    id: 's1',
+                    type: 'family-graph',
+                    label: 'F',
+                    order: 0,
+                    data: {
+                        persons: [
+                            {
+                                id: 'p1',
+                                name: '山田 太郎',
+                                role: null,
+                                birthday: null,
+                                address: null,
+                                deathDate: null,
+                            },
+                        ],
+                        relationships: [],
+                    },
+                },
+            ],
+        }
+        expect(validate(ok)).toBe(true)
+    })
+
     it('rejects a section missing its required `data`', () => {
         const bad = {
             ...base,


### PR DESCRIPTION
## Summary
- `role`, `birthday`, `address`, and `deathDate` on `FamilyGraphPerson` now accept `null` in addition to a string or omission. LLM-driven generators and TypeScript/OpenAPI codegens routinely emit `null` for "absent", and forcing producers to special-case alive persons surfaces as a cascading 85-error `oneOf` failure in the public viewer.
- Pure schema/types loosening: renderer and `jp-court` call sites already treat `null`/`undefined` identically via truthy guards and `?? ''`, so no runtime change.

## Changes
- `schemas/agent.schema.json` — four fields → `"type": ["string", "null"]`
- `packages/renderer/src/types.ts`, `packages/jp-court/src/index.tsx` — TS types → `string | null`
- `tests/schema.test.ts` — positive test asserting all four fields accept `null`
- `SPEC.md` § 4.12 + `CHANGELOG.md` — documented

Fixes #39.

## Out of scope
The issue's "bonus" — replacing the wide `Section` `oneOf` with `if`/`then` discrimination on `type` to stop ajv from cascading errors across every branch — is a larger UX change to validator output and belongs in its own PR.

## Test plan
- [x] `npx vitest run` — 8 files, 112 tests pass (new null-acceptance case included)
- [x] `npm run typecheck` in `packages/renderer` and `packages/jp-court`
- [x] Manually validated the exact repro `.agent` from issue #39 against the updated schema