### PR TITLE
Release: renderer 0.1.8, jp-court 0.1.4, mcp 0.2.3

### DIFF
--- a/packages/jp-court/package.json
+++ b/packages/jp-court/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-format/jp-court",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "@agent-format/renderer plugin: jp-court (相続関係説明図) visual template for family-graph sections. Japanese legal-filing typography, double-line spouse edges, PDF export. Does NOT filter persons — the .agent file is the source of truth.",
   "license": "MIT",
   "author": "Yuya Morita",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-format/mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "MCP Apps server that renders .agent files as interactive dashboards inline in Claude / ChatGPT / Cursor / VS Code Copilot.",
   "license": "MIT",
   "author": "Yuya Morita",
@@ -26,8 +26,8 @@
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.ui.json"
   },
   "dependencies": {
-    "@agent-format/jp-court": "0.1.3",
-    "@agent-format/renderer": "0.1.7",
+    "@agent-format/jp-court": "0.1.4",
+    "@agent-format/renderer": "0.1.8",
     "@modelcontextprotocol/ext-apps": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ajv": "^8.17.0",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-format/renderer",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "React renderer for the agent file format (.agent).",
   "license": "MIT",
   "author": "Yuya Morita",


### PR DESCRIPTION
Version bumps to pick up #40 (FamilyGraphPerson null-acceptance):

- `@agent-format/renderer` 0.1.7 → 0.1.8 (TS types: optional string fields → `string | null`)
- `@agent-format/jp-court` 0.1.3 → 0.1.4 (transitive — internal `Person` shape widened)
- `@agent-format/mcp` 0.2.2 → 0.2.3 (rebundled `agent.schema.json` accepts `null`; dep pins updated)

Pure additive change. No runtime behavior change — renderer/jp-court call sites already treat null/undefined identically via truthy guards and `?? ''`.

Tags `renderer-v0.1.8`, `jp-court-v0.1.4`, `mcp-v0.2.3` will be pushed after merge, triggering npm publish with provenance via `.github/workflows/release.yml`.

## Test plan
- [x] `npx vitest run` — 112 tests pass
- [x] `npm run typecheck` across renderer/jp-court
- [x] CI verify check on this branch